### PR TITLE
feat: persist run state in localStorage across page reloads

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { RouterOutlet } from '@angular/router';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { environment } from '../environments/environment';
 import { ThemeService } from './services/theme-service/theme.service';
+import { RunPersistenceService } from './services/run-persistence-service/run-persistence.service';
 
 @Component({
   selector: 'app-root',
@@ -20,6 +21,8 @@ export class AppComponent {
     // Eagerly instantiate ThemeService so the stored theme is applied on startup,
     // before any settings panel is opened.
     _theme: ThemeService,
+    // Eagerly instantiate RunPersistenceService to restore the previous run on startup.
+    _run: RunPersistenceService,
   ) {
     const savedLanguage = localStorage.getItem('language') || 'en';
     this.translate.addLangs(['en', 'es', 'fr', 'de', 'it', 'pt']);

--- a/src/app/main-game/main-game.component.ts
+++ b/src/app/main-game/main-game.component.ts
@@ -18,6 +18,7 @@ import { LanguageSelectorComponent } from './language-selector/language-selector
 import { RouletteContainerComponent } from './roulette-container/roulette-container.component';
 import { SettingsButtonComponent } from '../settings-button/settings-button.component';
 import { RareCandyService } from '../services/rare-candy-service/rare-candy.service';
+import { RunPersistenceService } from '../services/run-persistence-service/run-persistence.service';
 
 @Component({
   selector: 'app-main-game',
@@ -45,7 +46,8 @@ export class MainGameComponent implements OnInit {
     private trainerService: TrainerService,
     private modalService: NgbModal,
     private analyticsService: AnalyticsService,
-    private rareCandyService: RareCandyService) {
+    private rareCandyService: RareCandyService,
+    private runPersistenceService: RunPersistenceService) {
       this.darkMode = this.themeService.isDark$;
   }
 
@@ -77,6 +79,7 @@ export class MainGameComponent implements OnInit {
   }
 
   resetGame(): void {
+    this.runPersistenceService.clearSave();
     this.trainerService.resetTrainer();
     this.trainerService.resetTeam();
     this.trainerService.resetItems();

--- a/src/app/services/game-state-service/game-state.service.ts
+++ b/src/app/services/game-state-service/game-state.service.ts
@@ -98,4 +98,14 @@ export class GameStateService {
     this.finishCurrentState();
     this.currentRound.next(0);
   }
+
+  getStateStack(): GameState[] {
+    return [...this.stateStack];
+  }
+
+  restoreState(stateStack: GameState[], currentState: GameState, round: number): void {
+    this.stateStack = [...stateStack];
+    this.state.next(currentState);
+    this.currentRound.next(round);
+  }
 }

--- a/src/app/services/generation-service/generation.service.ts
+++ b/src/app/services/generation-service/generation.service.ts
@@ -7,8 +7,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 })
 export class GenerationService {
 
-  constructor() {
-  }
+  private readonly STORAGE_KEY = 'pokemon-roulette-generation';
 
   private generations: GenerationItem[] = [
     { text: 'Gen 1', region: 'Kanto', fillStyle: 'darkred', id: 1, weight: 1 },
@@ -22,14 +21,34 @@ export class GenerationService {
     { text: 'Gen 9', region: 'Paldea', fillStyle: 'darkviolet', id: 9, weight: 1 },
   ];
 
-  private generation = new BehaviorSubject<GenerationItem>(this.generations[0]);
+  private generation: BehaviorSubject<GenerationItem>;
+
+  constructor() {
+    const savedId = this.getSavedGenerationId();
+    const index = savedId !== null ? this.generations.findIndex(g => g.id === savedId) : -1;
+    const initial = index !== -1 ? this.generations[index] : this.generations[0];
+    this.generation = new BehaviorSubject<GenerationItem>(initial);
+  }
 
   getGenerationList(): GenerationItem[] {
     return this.generations;
   }
 
   setGeneration(index: number): void {
-    this.generation.next(this.generations[index]);
+    const gen = this.generations[index];
+    this.generation.next(gen);
+    localStorage.setItem(this.STORAGE_KEY, String(gen.id));
+  }
+
+  clearSavedGeneration(): void {
+    localStorage.removeItem(this.STORAGE_KEY);
+  }
+
+  private getSavedGenerationId(): number | null {
+    const saved = localStorage.getItem(this.STORAGE_KEY);
+    if (saved === null) return null;
+    const id = parseInt(saved, 10);
+    return isNaN(id) ? null : id;
   }
 
   getGeneration(): Observable<GenerationItem> {

--- a/src/app/services/run-persistence-service/run-persistence.service.ts
+++ b/src/app/services/run-persistence-service/run-persistence.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@angular/core';
+import { combineLatest, debounceTime, skip } from 'rxjs';
+import { GameState } from '../game-state-service/game-state';
+import { GameStateService } from '../game-state-service/game-state.service';
+import { TrainerService } from '../trainer-service/trainer.service';
+import { PokemonItem } from '../../interfaces/pokemon-item';
+import { ItemItem } from '../../interfaces/item-item';
+import { Badge } from '../../interfaces/badge';
+
+interface RunSave {
+  version: 1;
+  team: PokemonItem[];
+  stored: PokemonItem[];
+  items: ItemItem[];
+  badges: Badge[];
+  stateStack: GameState[];
+  currentState: GameState;
+  currentRound: number;
+  gender: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RunPersistenceService {
+
+  private readonly STORAGE_KEY = 'pokemon-roulette-run';
+  private readonly NO_SAVE_STATES = new Set<GameState>(['game-start', 'game-over', 'game-finish']);
+
+  constructor(
+    private trainerService: TrainerService,
+    private gameStateService: GameStateService,
+  ) {
+    this.loadRun();
+    this.startAutoSave();
+  }
+
+  clearSave(): void {
+    localStorage.removeItem(this.STORAGE_KEY);
+  }
+
+  private loadRun(): void {
+    const save = this.getSaveFromStorage();
+    if (!save) return;
+
+    this.trainerService.commitTeamAndStorage(save.team, save.stored);
+    this.trainerService.restoreItems(save.items);
+    this.trainerService.restoreBadges(save.badges);
+    this.trainerService.gender = save.gender;
+    this.gameStateService.restoreState(save.stateStack, save.currentState, save.currentRound);
+  }
+
+  private startAutoSave(): void {
+    combineLatest([
+      this.trainerService.getTeamObservable(),
+      this.trainerService.getItemsObservable(),
+      this.trainerService.getBadgesObservable(),
+      this.gameStateService.currentState,
+      this.gameStateService.currentRoundObserver,
+    ]).pipe(
+      skip(1),
+      debounceTime(300),
+    ).subscribe(([_team, items, badges, currentState, currentRound]) => {
+      if (this.NO_SAVE_STATES.has(currentState)) return;
+      this.saveRun(currentState, currentRound, items, badges);
+    });
+  }
+
+  private saveRun(currentState: GameState, currentRound: number, items: ItemItem[], badges: Badge[]): void {
+    const save: RunSave = {
+      version: 1,
+      team: this.trainerService.getTeam(),
+      stored: this.trainerService.getStored(),
+      items,
+      badges,
+      stateStack: this.gameStateService.getStateStack(),
+      currentState,
+      currentRound,
+      gender: this.trainerService.gender,
+    };
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(save));
+  }
+
+  private getSaveFromStorage(): RunSave | null {
+    const raw = localStorage.getItem(this.STORAGE_KEY);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as RunSave;
+      if (parsed.version !== 1) return null;
+      return parsed;
+    } catch {
+      console.error('Invalid run save in localStorage, discarding.');
+      localStorage.removeItem(this.STORAGE_KEY);
+      return null;
+    }
+  }
+}

--- a/src/app/services/trainer-service/trainer.service.ts
+++ b/src/app/services/trainer-service/trainer.service.ts
@@ -267,6 +267,16 @@ export class TrainerService implements OnDestroy {
     this.trainerBadgesObservable.next(this.trainerBadges);
   }
 
+  restoreItems(items: ItemItem[]): void {
+    this.trainerItems = [...items];
+    this.trainerItemsObservable.next(this.trainerItems);
+  }
+
+  restoreBadges(badges: Badge[]): void {
+    this.trainerBadges = [...badges];
+    this.trainerBadgesObservable.next(this.trainerBadges);
+  }
+
   // Applies all battle-entry transforms in one pass with a single emit.
   // Temporary forms apply to team+stored; sticky forms apply to team only.
   private applyBattleForms(): void {


### PR DESCRIPTION
## Problem

Refreshing the page or closing the browser resets all progress — team, items, badges, game state, and Pokédex tracking are lost entirely.

## Solution

Adds `RunPersistenceService`, which auto-saves run state to `localStorage` on every meaningful state change (debounced 300 ms) and restores it on startup.

**What is saved:**
- Team and box (Pokémon + shiny flag)
- Items and badges
- Full game state stack + current state + round index
- Selected generation and trainer gender

**What is NOT saved:** transient UI state (`game-start`, `game-over`, `game-finish`).

**On new game:** `resetGame()` calls `clearSave()` before resetting services, so the save slot is wiped cleanly.

## Changes

| File | Change |
|---|---|
| `run-persistence.service.ts` | New service — save / load / clear logic |
| `generation.service.ts` | Reads saved generation in constructor so `GameStateService` initialises its state stack for the correct generation on startup (fixes the Gen 1 reset bug seen in #24) |
| `game-state.service.ts` | Adds `getStateStack()` + `restoreState()` for round-trip serialisation |
| `trainer.service.ts` | Adds `restoreItems()` + `restoreBadges()` to keep observables consistent on hydration |
| `app.component.ts` | Eagerly injects `RunPersistenceService` (same pattern as `ThemeService`) |
| `main-game.component.ts` | Calls `clearSave()` at the start of `resetGame()` |

## Scope

Intentionally minimal — no new UI, no new dependencies, no feature flags. This partially addresses the need described in #22 (single-device persistence without an account), but does not replace a login system or cross-device sync.