### PR TITLE
feat: Safari Zone slice for Kanto, on a pattern that supports region-only slices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npm run deploy                                   # gh-pages, base-href /pokemon-
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
 
-**Green baseline:** build passes, **336/336 tests pass**. Any change must leave both green.
+**Green baseline:** build passes, **368/368 tests pass**. Any change must leave both green.
 
 ### Local environment gotchas
 
@@ -77,6 +77,14 @@ These were raised deliberately. The previous values (1 MB / 4 kB) were breached 
 exp-share, running shoes, a stolen Pokémon). They live there rather than on the container because
 the container is never destroyed, so a restart would otherwise leave them set.
 
+The **main adventure wheel** is data: `roulettes/main-adventure-roulette/adventure-actions.ts` holds
+every slice, and `AdventureActionName` is *derived* from that list. The component maps names to
+outputs through a `Record<AdventureActionName, () => void>`, so adding a slice is a compile error
+until it has a handler, which is a compile error until it has an `@Output`. Slices carry an optional
+`generations` array (Safari Zone is Kanto-only, Area Zero Paldea-only), and dispatch is by name,
+never by wheel index — a region-only slice makes one index mean different things in different
+regions. The other five index-switch roulettes are fine: none is generation-gated.
+
 `RouletteContainerComponent` subscribes to `currentState`; its template is one `@switch` over the
 state rendering exactly one roulette per state, with a `@default` arm so an unhandled state fails
 loudly instead of blanking the screen. Its handler methods are the transition table. It is ~1050
@@ -110,9 +118,12 @@ and releases the global `wheelSpinning` gate on any throw; that gate disables mo
 never latch it without a path that clears it.
 
 Per-generation content lives in sibling data files (`fish-by-generation.ts`,
-`gym-leaders-by-generation.ts`, …), keyed by generation id 1–9. **Five pool roulettes — fishing,
-fossil, legendary, starter, cave — are one `PokemonPoolRouletteComponent`** driven by
-`POKEMON_POOLS`; add a pool by adding a row, not a component. The other 26 roulettes are
+`gym-leaders-by-generation.ts`, …), keyed by generation id 1–9. **Six pool roulettes — fishing,
+fossil, legendary, starter, cave, safari — are one `PokemonPoolRouletteComponent`** driven by
+`POKEMON_POOLS`; add a pool by adding a row, not a component. A pool may declare `rareBoost` to
+widen named slices past a given round — Safari Zone's seven prizes double after the fourth gym.
+**That boost clones**: `getPokemonByIdArray` returns the shared National Dex objects, so assigning
+`weight` would change them on every wheel for the rest of the session. The other 26 roulettes are
 deliberately separate: they emit into different typed outputs and collapsing them would trade
 compile-time checking for runtime string matching.
 
@@ -157,7 +168,7 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 
 Six locales in `src/assets/i18n/*.json` (en, pt, es, fr, de, it), loaded over HTTP by `TranslateHttpLoader`. User-facing strings are **never** literals — data files store dotted keys (`items.potion.name`, `game.main.roulette.fishing.title`) that templates resolve with the `translate` pipe. Adding a string means adding it to all six files.
 
-**All six files hold an identical key set** (2,207 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
+**All six files hold an identical key set** (2,210 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
 
 ```bash
 node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"

--- a/src/app/main-game/roulette-container/roulette-container.component.html
+++ b/src/app/main-game/roulette-container/roulette-container.component.html
@@ -92,6 +92,7 @@
         (goFishingEvent)="goFishing()"
         (findFossilEvent)="findFossil()"
         (battleRivalEvent)="battleRival()"
+        (safariZoneEvent)="safariZone()"
         (areaZeroEvent)="areaZero()">
     </app-main-adventure-roulette>
   }
@@ -130,6 +131,13 @@
     <app-find-item-roulette
         (itemSelectedEvent)="receiveItem($event)">
     </app-find-item-roulette>
+  }
+  @case ('safari-zone') {
+    <app-pokemon-pool-roulette
+        pool="safari"
+        [currentRound]="leadersDefeatedAmount"
+        (selectedPokemonEvent)="capturePokemon($event)">
+    </app-pokemon-pool-roulette>
   }
   @case ('area-zero') {
     <app-area-zero-roulette

--- a/src/app/main-game/roulette-container/roulette-container.component.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.ts
@@ -550,6 +550,11 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
     this.finishCurrentState();
   }
 
+  safariZone(): void {
+    this.gameStateService.setNextState('safari-zone');
+    this.finishCurrentState();
+  }
+
   areaZero(): void {
     this.gameStateService.setNextState('area-zero');
     this.finishCurrentState();

--- a/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/adventure-actions.ts
+++ b/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/adventure-actions.ts
@@ -1,0 +1,67 @@
+import { WheelItem } from '../../../../interfaces/wheel-item';
+
+/**
+ * Shape check for the rows below. Not exported: `name` is narrowed to {@link AdventureActionName}
+ * once the rows exist, and {@link AdventureAction} is the type everything else should use.
+ */
+interface AdventureActionRow extends WheelItem {
+  readonly name: string;
+  readonly generations?: readonly number[];
+}
+
+/**
+ * Every adventure slice, in wheel order.
+ *
+ * `as const satisfies` earns both halves: `satisfies` reports a malformed row at the row itself,
+ * and `as const` keeps `name` a literal so the union below can be derived from this list rather
+ * than maintained alongside it.
+ */
+const ROWS = [
+  { name: 'catchPokemon', text: 'game.main.roulette.adventure.actions.catchPokemon', fillStyle: 'crimson', weight: 3 },
+  { name: 'battleTrainer', text: 'game.main.roulette.adventure.actions.battleTrainer', fillStyle: 'darkorange', weight: 1 },
+  { name: 'buyPotions', text: 'game.main.roulette.adventure.actions.buyPotions', fillStyle: 'darkgoldenrod', weight: 1 },
+  { name: 'goStraight', text: 'game.main.roulette.adventure.actions.goStraight', fillStyle: 'green', weight: 1 },
+  { name: 'catchTwoPokemon', text: 'game.main.roulette.adventure.actions.catchTwoPokemon', fillStyle: 'darkcyan', weight: 1 },
+  { name: 'visitDaycare', text: 'game.main.roulette.adventure.actions.visitDaycare', fillStyle: 'blue', weight: 1 },
+  { name: 'teamRocket', text: 'game.main.roulette.adventure.actions.teamRocket', fillStyle: 'purple', weight: 1 },
+  { name: 'mysteriousEgg', text: 'game.main.roulette.adventure.actions.mysteriousEgg', fillStyle: 'deeppink', weight: 1 },
+  { name: 'legendaryEncounter', text: 'game.main.roulette.adventure.actions.legendaryEncounter', fillStyle: 'crimson', weight: 1 },
+  { name: 'tradePokemon', text: 'game.main.roulette.adventure.actions.tradePokemon', fillStyle: 'darkorange', weight: 1 },
+  { name: 'findItem', text: 'game.main.roulette.adventure.actions.findItem', fillStyle: 'darkgoldenrod', weight: 1 },
+  { name: 'exploreCave', text: 'game.main.roulette.adventure.actions.exploreCave', fillStyle: 'green', weight: 1 },
+  { name: 'snorlaxEncounter', text: 'game.main.roulette.adventure.actions.snorlaxEncounter', fillStyle: 'darkcyan', weight: 1 },
+  { name: 'multitask', text: 'game.main.roulette.adventure.actions.multitask', fillStyle: 'blue', weight: 1 },
+  { name: 'goFishing', text: 'game.main.roulette.adventure.actions.goFishing', fillStyle: 'purple', weight: 1 },
+  { name: 'findFossil', text: 'game.main.roulette.adventure.actions.findFossil', fillStyle: 'deeppink', weight: 1 },
+  { name: 'battleRival', text: 'game.main.roulette.adventure.actions.battleRival', fillStyle: 'black', weight: 1 },
+
+  // Region-only slices. Each belongs to exactly one generation, so no player sees both.
+  { name: 'safariZone', text: 'game.main.roulette.adventure.actions.safariZone', fillStyle: 'olivedrab', weight: 1, generations: [1] },
+  { name: 'areaZero', text: 'game.main.roulette.adventure.actions.areaZero', fillStyle: 'darkslateblue', weight: 1, generations: [9] },
+] as const satisfies readonly AdventureActionRow[];
+
+/** Every slice name, derived from the rows so the two cannot drift apart. */
+export type AdventureActionName = typeof ROWS[number]['name'];
+
+/**
+ * One slice of the main adventure wheel.
+ *
+ * The wheel reports the index of whatever array it was handed, so the slice list and the dispatch
+ * table have to agree. Naming each slice is what lets them agree: the component maps names to
+ * outputs through a `Record`, so a slice that only exists in some regions cannot change what an
+ * index means everywhere else.
+ */
+export interface AdventureAction extends WheelItem {
+  readonly name: AdventureActionName;
+  /** Generations this slice appears in. Omitted means every generation. */
+  readonly generations?: readonly number[];
+}
+
+export const ADVENTURE_ACTIONS: readonly AdventureAction[] = ROWS;
+
+/** The slices on offer in a given generation, in wheel order. */
+export function adventureActionsFor(generationId: number): AdventureAction[] {
+  return ADVENTURE_ACTIONS.filter(
+    action => !action.generations || action.generations.includes(generationId),
+  );
+}

--- a/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.spec.ts
@@ -4,7 +4,39 @@ import { BehaviorSubject } from 'rxjs';
 import { GenerationItem } from '../../../../interfaces/generation-item';
 import { GenerationService } from '../../../../services/generation-service/generation.service';
 
+import { EventEmitter } from '@angular/core';
+
 import { MainAdventureRouletteComponent } from './main-adventure-roulette.component';
+import { ADVENTURE_ACTIONS, AdventureActionName } from './adventure-actions';
+
+/**
+ * The output each slice is expected to fire.
+ *
+ * A `Record` over the derived name union, so a new slice cannot be added without deciding what it
+ * emits here too. Three names do not follow the `<name>Event` convention, which is exactly the kind
+ * of thing an index-based test could never have caught.
+ */
+const OUTPUT_BY_ACTION: Record<AdventureActionName, string> = {
+  catchPokemon: 'catchPokemonEvent',
+  battleTrainer: 'battleTrainerEvent',
+  buyPotions: 'buyPotionsEvent',
+  goStraight: 'doNothingEvent',
+  catchTwoPokemon: 'catchTwoPokemonEvent',
+  visitDaycare: 'visitDaycareEvent',
+  teamRocket: 'teamRocketEncounterEvent',
+  mysteriousEgg: 'mysteriousEggEvent',
+  legendaryEncounter: 'legendaryEncounterEvent',
+  tradePokemon: 'tradePokemonEvent',
+  findItem: 'findItemEvent',
+  exploreCave: 'exploreCaveEvent',
+  snorlaxEncounter: 'snorlaxEncounterEvent',
+  multitask: 'multitaskEvent',
+  goFishing: 'goFishingEvent',
+  findFossil: 'findFossilEvent',
+  battleRival: 'battleRivalEvent',
+  safariZone: 'safariZoneEvent',
+  areaZero: 'areaZeroEvent',
+};
 
 describe('MainAdventureRouletteComponent', () => {
   let component: MainAdventureRouletteComponent;
@@ -46,24 +78,65 @@ describe('MainAdventureRouletteComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should keep the base action list for non-gen-9 generations', () => {
-    expect(component.actions.length).toBe(17);
-    expect(component.actions.some(action => action.text === 'game.main.roulette.adventure.actions.areaZero')).toBeFalse();
+  describe('region-only slices', () => {
+    const namesFor = (generationId: number): string[] => {
+      generationSubject.next(createGeneration(generationId));
+      fixture.detectChanges();
+      return component.actions.map(action => action.name);
+    };
+
+    it('offers Safari Zone in Kanto and Area Zero nowhere else', () => {
+      const kanto = namesFor(1);
+
+      expect(kanto).toContain('safariZone');
+      expect(kanto).not.toContain('areaZero');
+    });
+
+    it('offers Area Zero in Paldea and Safari Zone nowhere else', () => {
+      const paldea = namesFor(9);
+
+      expect(paldea).toContain('areaZero');
+      expect(paldea).not.toContain('safariZone');
+    });
+
+    it('offers neither in a region that has no special slice', () => {
+      const sinnoh = namesFor(4);
+
+      expect(sinnoh).not.toContain('safariZone');
+      expect(sinnoh).not.toContain('areaZero');
+      expect(sinnoh.length).toBe(ADVENTURE_ACTIONS.filter(a => !a.generations).length);
+    });
   });
 
-  it('should append the Area Zero action for generation 9', () => {
-    generationSubject.next(createGeneration(9));
-    fixture.detectChanges();
+  describe('dispatch', () => {
+    // The reason this component stopped dispatching on wheel index: with two region-only slices,
+    // one index means different things in different regions. Every slice is checked in the region
+    // it actually appears in.
+    for (const action of ADVENTURE_ACTIONS) {
+      it(`fires only ${action.name}`, () => {
+        generationSubject.next(createGeneration(action.generations?.[0] ?? 4));
+        fixture.detectChanges();
 
-    expect(component.actions.length).toBe(18);
-    expect(component.actions[17].text).toBe('game.main.roulette.adventure.actions.areaZero');
+        const spies = new Map<AdventureActionName, jasmine.Spy>();
+        for (const name of Object.keys(OUTPUT_BY_ACTION) as AdventureActionName[]) {
+          const emitter = (component as unknown as Record<string, EventEmitter<unknown>>)[OUTPUT_BY_ACTION[name]];
+          spies.set(name, spyOn(emitter, 'emit'));
+        }
+
+        const index = component.actions.findIndex(candidate => candidate.name === action.name);
+        expect(index).withContext(`${action.name} is missing from its own region`).toBeGreaterThanOrEqual(0);
+
+        component.onItemSelected(index);
+
+        for (const [name, spy] of spies) {
+          if (name === action.name) {
+            expect(spy).withContext(`${name} should have fired`).toHaveBeenCalled();
+          } else {
+            expect(spy).withContext(`${name} fired for ${action.name}`).not.toHaveBeenCalled();
+          }
+        }
+      });
+    }
   });
 
-  it('should emit the Area Zero event from the gen-9-only slot', () => {
-    spyOn(component.areaZeroEvent, 'emit');
-
-    component.onItemSelected(17);
-
-    expect(component.areaZeroEvent.emit).toHaveBeenCalled();
-  });
 });

--- a/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.ts
@@ -1,8 +1,8 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ChangeDetectionStrategy } from '@angular/core';
 import {TranslatePipe} from '@ngx-translate/core';
 import { WheelComponent } from '../../../../wheel/wheel.component';
-import { WheelItem } from '../../../../interfaces/wheel-item';
 import { EventSource } from '../../../EventSource';
+import { AdventureAction, AdventureActionName, adventureActionsFor } from './adventure-actions';
 import { GenerationService } from '../../../../services/generation-service/generation.service';
 import { Subscription } from 'rxjs';
 
@@ -38,41 +38,48 @@ export class MainAdventureRouletteComponent implements OnInit, OnDestroy {
   @Output() findFossilEvent = new EventEmitter<void>();
   @Output() battleRivalEvent = new EventEmitter<void>();
   @Output() areaZeroEvent = new EventEmitter<void>();
+  @Output() safariZoneEvent = new EventEmitter<void>();
 
-  private readonly baseActions: WheelItem[] = [
-    { text: 'game.main.roulette.adventure.actions.catchPokemon', fillStyle: 'crimson', weight: 3 },
-    { text: 'game.main.roulette.adventure.actions.battleTrainer', fillStyle: 'darkorange', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.buyPotions', fillStyle: 'darkgoldenrod', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.goStraight', fillStyle: 'green', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.catchTwoPokemon', fillStyle: 'darkcyan', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.visitDaycare', fillStyle: 'blue', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.teamRocket', fillStyle: 'purple', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.mysteriousEgg', fillStyle: 'deeppink', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.legendaryEncounter', fillStyle: 'crimson', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.tradePokemon', fillStyle: 'darkorange', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.findItem', fillStyle: 'darkgoldenrod', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.exploreCave', fillStyle: 'green', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.snorlaxEncounter', fillStyle: 'darkcyan', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.multitask', fillStyle: 'blue', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.goFishing', fillStyle: 'purple', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.findFossil', fillStyle: 'deeppink', weight: 1 },
-    { text: 'game.main.roulette.adventure.actions.battleRival', fillStyle: 'black', weight: 1 },
-  ];
+  /**
+   * Mutable on purpose: `WheelComponent`'s `items` input is `WheelItem[]`, and a readonly array
+   * will not bind to it under `strictTemplates`.
+   */
+  actions: AdventureAction[] = adventureActionsFor(1);
 
-  private readonly areaZeroAction: WheelItem = {
-    text: 'game.main.roulette.adventure.actions.areaZero',
-    fillStyle: 'darkslateblue',
-    weight: 1
+  /**
+   * What each slice does. Keyed by name rather than by wheel index, so a slice that only exists in
+   * some regions cannot change what a given index means elsewhere.
+   *
+   * `Record<AdventureActionName, …>` is exhaustive: adding a row to `ADVENTURE_ACTIONS` without a
+   * handler here is a compile error, and so is a handler for a row that no longer exists.
+   */
+  private readonly handlers: Record<AdventureActionName, () => void> = {
+    catchPokemon: () => this.catchPokemonEvent.emit(),
+    battleTrainer: () => this.battleTrainerEvent.emit('battle-trainer'),
+    buyPotions: () => this.buyPotionsEvent.emit(),
+    goStraight: () => this.doNothingEvent.emit(),
+    catchTwoPokemon: () => this.catchTwoPokemonEvent.emit(),
+    visitDaycare: () => this.visitDaycareEvent.emit('visit-daycare'),
+    teamRocket: () => this.teamRocketEncounterEvent.emit(),
+    mysteriousEgg: () => this.mysteriousEggEvent.emit(),
+    legendaryEncounter: () => this.legendaryEncounterEvent.emit(),
+    tradePokemon: () => this.tradePokemonEvent.emit(),
+    findItem: () => this.findItemEvent.emit(),
+    exploreCave: () => this.exploreCaveEvent.emit(),
+    snorlaxEncounter: () => this.snorlaxEncounterEvent.emit(),
+    multitask: () => this.multitaskEvent.emit(),
+    goFishing: () => this.goFishingEvent.emit(),
+    findFossil: () => this.findFossilEvent.emit(),
+    battleRival: () => this.battleRivalEvent.emit(),
+    safariZone: () => this.safariZoneEvent.emit(),
+    areaZero: () => this.areaZeroEvent.emit(),
   };
 
-  actions: WheelItem[] = [...this.baseActions];
   private generationSubscription: Subscription | null = null;
 
   ngOnInit(): void {
     this.generationSubscription = this.generationService.getGeneration().subscribe(generation => {
-      this.actions = generation.id === 9
-        ? [...this.baseActions, this.areaZeroAction]
-        : [...this.baseActions];
+      this.actions = adventureActionsFor(generation.id);
     });
   }
 
@@ -81,62 +88,6 @@ export class MainAdventureRouletteComponent implements OnInit, OnDestroy {
   }
 
   onItemSelected(index: number): void {
-    switch (index) {
-      case 0:
-        this.catchPokemonEvent.emit();
-        break;
-      case 1:
-        this.battleTrainerEvent.emit('battle-trainer');
-        break;
-      case 2:
-        this.buyPotionsEvent.emit();
-        break;
-      case 3:
-        this.doNothingEvent.emit();
-        break;
-      case 4:
-        this.catchTwoPokemonEvent.emit();
-        break;
-      case 5:
-        this.visitDaycareEvent.emit('visit-daycare');
-        break;
-      case 6:
-        this.teamRocketEncounterEvent.emit();
-        break;
-      case 7:
-        this.mysteriousEggEvent.emit();
-        break;
-      case 8:
-        this.legendaryEncounterEvent.emit();
-        break;
-      case 9:
-        this.tradePokemonEvent.emit();
-        break;
-      case 10:
-        this.findItemEvent.emit();
-        break;
-      case 11:
-        this.exploreCaveEvent.emit();
-        break;
-      case 12:
-        this.snorlaxEncounterEvent.emit();
-        break;
-      case 13:
-        this.multitaskEvent.emit();
-        break;
-      case 14:
-        this.goFishingEvent.emit();
-        break;
-      case 15:
-        this.findFossilEvent.emit();
-        break;
-      case 16:
-        this.battleRivalEvent.emit();
-        break;
-      case 17:
-        this.areaZeroEvent.emit();
-        break;
-    }
+    this.handlers[this.actions[index].name]();
   }
 }
-

--- a/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.spec.ts
@@ -4,6 +4,7 @@ import { PokemonPoolRouletteComponent } from './pokemon-pool-roulette.component'
 import { POKEMON_POOLS, PokemonPoolId } from './pokemon-pools';
 import { GenerationService } from '../../../../services/generation-service/generation.service';
 import { PokemonItem } from '../../../../interfaces/pokemon-item';
+import { PokemonService } from '../../../../services/pokemon-service/pokemon.service';
 
 describe('PokemonPoolRouletteComponent', () => {
   let fixture: ComponentFixture<PokemonPoolRouletteComponent>;
@@ -23,6 +24,52 @@ describe('PokemonPoolRouletteComponent', () => {
     generationService = TestBed.inject(GenerationService);
   });
 
+  describe('the Safari Zone rare boost', () => {
+    const CHANSEY = 113;
+    const NIDORAN_F = 29;
+
+    const loadSafari = (currentRound: number): void => {
+      component.pool = 'safari';
+      component.currentRound = currentRound;
+      fixture.detectChanges();
+    };
+
+    const weightOf = (pokemonId: number): number | undefined =>
+      component.pokemon.find(p => p.pokemonId === pokemonId)?.weight;
+
+    it('draws evenly before the fourth gym', () => {
+      loadSafari(3);
+
+      expect(weightOf(CHANSEY)).toBe(1);
+      expect(weightOf(NIDORAN_F)).toBe(1);
+    });
+
+    it('widens the prizes once the fourth gym is behind you', () => {
+      loadSafari(4);
+
+      expect(weightOf(CHANSEY)).withContext('a prize should be easier to land late').toBe(2);
+      expect(weightOf(NIDORAN_F)).withContext('common species are unchanged').toBe(1);
+    });
+
+    it('does not touch the shared National Dex entry', () => {
+      loadSafari(8);
+      expect(weightOf(CHANSEY)).toBe(2);
+
+      // getPokemonByIdArray hands back the dex objects themselves; boosting by assignment would
+      // leave Chansey heavier on every other wheel for the rest of the session.
+      const dexChansey = TestBed.inject(PokemonService).getPokemonById(CHANSEY) as PokemonItem;
+      expect(dexChansey.weight).withContext('the boost must clone, not mutate').toBe(1);
+    });
+
+    it('leaves pools without a boost alone', () => {
+      component.pool = 'cave';
+      component.currentRound = 8;
+      fixture.detectChanges();
+
+      expect(component.pokemon.every(p => p.weight === 1)).toBeTrue();
+    });
+  });
+
   it('should create', () => {
     component.pool = 'fish';
     fixture.detectChanges();
@@ -31,7 +78,7 @@ describe('PokemonPoolRouletteComponent', () => {
 
   // One component now serves five wheels, so every pool is exercised rather than
   // each getting its own "should create".
-  for (const pool of ['fish', 'fossil', 'legendary', 'starter', 'cave'] as PokemonPoolId[]) {
+  for (const pool of poolIds) {
     it(`loads the ${pool} pool for the current generation`, () => {
       component.pool = pool;
       fixture.detectChanges();

--- a/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.spec.ts
@@ -61,6 +61,21 @@ describe('PokemonPoolRouletteComponent', () => {
       expect(dexChansey.weight).withContext('the boost must clone, not mutate').toBe(1);
     });
 
+    it('does not let the boost travel with the captured Pokémon', () => {
+      loadSafari(8);
+      const index = component.pokemon.findIndex(p => p.pokemonId === CHANSEY);
+      expect(component.pokemon[index].weight).withContext('boosted on the wheel').toBe(2);
+
+      let captured: PokemonItem | undefined;
+      component.selectedPokemonEvent.subscribe(p => (captured = p));
+      component.onItemSelected(index);
+
+      // Team-driven wheels bind their Pokémon straight into `[items]`, so a boosted weight here
+      // would give Chansey a double-width slice on the evolution, trade and mega wheels.
+      expect(captured?.pokemonId).toBe(CHANSEY);
+      expect(captured?.weight).withContext('the boost is for this spin only').toBe(1);
+    });
+
     it('leaves pools without a boost alone', () => {
       component.pool = 'cave';
       component.currentRound = 8;

--- a/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.ts
@@ -18,6 +18,8 @@ import { POKEMON_POOLS, PokemonPool, PokemonPoolId } from './pokemon-pools';
 })
 export class PokemonPoolRouletteComponent implements OnInit, OnDestroy {
   @Input({ required: true }) pool!: PokemonPoolId;
+  /** Battles won so far. Only pools with a `rareBoost` read it. */
+  @Input() currentRound = 0;
   @Output() selectedPokemonEvent = new EventEmitter<PokemonItem>();
 
   generation!: GenerationItem;
@@ -38,7 +40,7 @@ export class PokemonPoolRouletteComponent implements OnInit, OnDestroy {
     this.generationSubscription = this.generationService.getGeneration().subscribe(generation => {
       this.generation = generation;
       const ids = this.poolDefinition.idsByGeneration[generation.id] ?? [];
-      this.pokemon = this.pokemonService.getPokemonByIdArray(ids);
+      this.pokemon = this.applyRareBoost(this.pokemonService.getPokemonByIdArray(ids));
     });
   }
 
@@ -48,5 +50,24 @@ export class PokemonPoolRouletteComponent implements OnInit, OnDestroy {
 
   onItemSelected(index: number): void {
     this.selectedPokemonEvent.emit(this.pokemon[index]);
+  }
+
+  /**
+   * Widens this pool's rare slices once the player is far enough in.
+   *
+   * Builds new objects rather than assigning `weight`: `getPokemonByIdArray` hands back the shared
+   * National Dex entries, so writing to them would leave Chansey at the boosted weight everywhere
+   * for the rest of the session — other wheels included.
+   */
+  private applyRareBoost(pokemon: PokemonItem[]): PokemonItem[] {
+    const boost = this.poolDefinition.rareBoost;
+
+    if (!boost || this.currentRound < boost.fromRound) {
+      return pokemon;
+    }
+
+    return pokemon.map(candidate => boost.ids.includes(candidate.pokemonId)
+      ? { ...candidate, weight: boost.weight }
+      : candidate);
   }
 }

--- a/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.ts
@@ -48,8 +48,16 @@ export class PokemonPoolRouletteComponent implements OnInit, OnDestroy {
     this.generationSubscription?.unsubscribe();
   }
 
+  /**
+   * Emits the Pokémon as the Dex knows it, leaving any wheel-only boost behind.
+   *
+   * `rareBoost` widens a slice for this spin, but the boosted weight must not travel with the
+   * Pokémon: every wheel built from the team binds those objects directly, so a captured Chansey
+   * carrying weight 2 would keep a double-width slice on the evolution, trade and mega wheels.
+   */
   onItemSelected(index: number): void {
-    this.selectedPokemonEvent.emit(this.pokemon[index]);
+    const chosen = this.pokemon[index];
+    this.selectedPokemonEvent.emit(this.pokemonService.getPokemonById(chosen.pokemonId) ?? chosen);
   }
 
   /**

--- a/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pools.ts
+++ b/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pools.ts
@@ -3,6 +3,7 @@ import { fossilByGeneration } from '../fossil-roulette/fossil-by-generation';
 import { legendaryByGeneration } from '../legendary-roulette/legendaries-by-generation';
 import { starterByGeneration } from '../starter-roulette/starter-by-generation';
 import { cavePokemonByGeneration } from '../cave-pokemon-roulette/cave-pokemon-by-generation';
+import { safariZoneByGeneration, safariZonePrizeIds } from './safari-zone-by-generation';
 
 /**
  * A "pick a Pokémon from this region's set" wheel.
@@ -17,6 +18,16 @@ export interface PokemonPool {
   /** Whether the heading names the generation. Starters do not — the region is already implied. */
   readonly showGeneration: boolean;
   readonly idsByGeneration: Record<number, number[]>;
+  /**
+   * Slices that widen once the player is far enough into the run, so a late visit is worth more
+   * than an early one. Omitted by every pool that draws evenly.
+   */
+  readonly rareBoost?: {
+    readonly ids: readonly number[];
+    readonly weight: number;
+    /** Battles won, compared against the roulette's `currentRound`. */
+    readonly fromRound: number;
+  };
 }
 
 export const POKEMON_POOLS = {
@@ -44,6 +55,13 @@ export const POKEMON_POOLS = {
     titleKey: 'game.main.roulette.cave.which',
     showGeneration: true,
     idsByGeneration: cavePokemonByGeneration,
+  },
+  safari: {
+    titleKey: 'game.main.roulette.safariZone.which',
+    // Kanto is already implied — the slice that leads here exists nowhere else.
+    showGeneration: false,
+    idsByGeneration: safariZoneByGeneration,
+    rareBoost: { ids: safariZonePrizeIds, weight: 2, fromRound: 4 },
   },
 } as const satisfies Record<string, PokemonPool>;
 

--- a/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/safari-zone-by-generation.ts
+++ b/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/safari-zone-by-generation.ts
@@ -1,0 +1,52 @@
+/**
+ * The Kanto Safari Zone catch pool.
+ *
+ * Red/Blue/Yellow and FireRed/LeafGreen encounters, minus the water ones — Psyduck, Poliwag,
+ * Slowpoke, Krabby, Goldeen, Magikarp and their evolutions overlap too heavily with the generation
+ * 1 fishing wheel to be worth a second appearance here.
+ *
+ * Only generation 1 has a Safari Zone in this game, so this is deliberately a one-key table: the
+ * slice that leads here is itself gated to Kanto.
+ */
+export const safariZoneByGeneration: Record<number, number[]> = {
+  1: [
+    29,  // Nidoran♀
+    30,  // Nidorina
+    32,  // Nidoran♂
+    33,  // Nidorino
+    46,  // Paras
+    47,  // Parasect
+    48,  // Venonat
+    49,  // Venomoth
+    84,  // Doduo
+    85,  // Dodrio
+    102, // Exeggcute
+    104, // Cubone
+    105, // Marowak
+    111, // Rhyhorn
+    113, // Chansey
+    114, // Tangela
+    115, // Kangaskhan
+    123, // Scyther
+    127, // Pinsir
+    128, // Tauros
+    147, // Dratini
+    148, // Dragonair
+  ],
+};
+
+/**
+ * The Safari Zone's headline catches — the reason to walk in.
+ *
+ * Three of them (Kangaskhan, Scyther, Pinsir) have mega forms, and Dratini is the start of a
+ * pseudo-legendary line, so landing on one late in a run is worth more than an early Nidoran.
+ */
+export const safariZonePrizeIds: readonly number[] = [
+  113, // Chansey
+  115, // Kangaskhan
+  123, // Scyther
+  127, // Pinsir
+  128, // Tauros
+  147, // Dratini
+  148, // Dragonair
+];

--- a/src/app/services/game-state-service/game-state.ts
+++ b/src/app/services/game-state-service/game-state.ts
@@ -18,6 +18,7 @@ export type GameState =
   | 'catch-legendary'
   | 'trade-pokemon'
   | 'find-item'
+  | 'safari-zone'
   | 'area-zero'
   | 'catch-paradox'
   | 'explore-cave'

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -257,8 +257,12 @@
             "goFishing": "Gehe angeln",
             "findFossil": "Finde ein Fossil",
             "battleRival": "Rivalen-Kampf",
+            "safariZone": "Besuche die Safari-Zone",
             "areaZero": "Erkunde Zone Null"
           }
+        },
+        "safariZone": {
+          "which": "Welches Pokémon der Safari-Zone?"
         },
         "areaZero": {
           "title": "Paradox-Pokémon",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -257,8 +257,12 @@
             "goFishing": "Go Fishing",
             "findFossil": "Find a Fossil",
             "battleRival": "Battle Rival",
+            "safariZone": "Visit the Safari Zone",
             "areaZero": "Explore Area Zero"
           }
+        },
+        "safariZone": {
+          "which": "Which Safari Zone Pokémon?"
         },
         "areaZero": {
           "title": "Paradox Pokémon",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -257,8 +257,12 @@
             "goFishing": "Pescar",
             "findFossil": "Encontrar un fósil",
             "battleRival": "Combate contra el Rival",
+            "safariZone": "Visitar la Zona Safari",
             "areaZero": "Explorar el Área Cero"
           }
+        },
+        "safariZone": {
+          "which": "¿Qué Pokémon de la Zona Safari?"
         },
         "areaZero": {
           "title": "Pokémon paradoja",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -257,8 +257,12 @@
             "goFishing": "Pêcher",
             "findFossil": "Trouver un fossile",
             "battleRival": "Combattre le rival",
+            "safariZone": "Visiter le Parc Safari",
             "areaZero": "Explorer la Zone Zéro"
           }
+        },
+        "safariZone": {
+          "which": "Quel Pokémon du Parc Safari ?"
         },
         "areaZero": {
           "title": "Pokémon Paradoxe",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -257,8 +257,12 @@
             "goFishing": "Vai a pescare",
             "findFossil": "Trova un fossile",
             "battleRival": "Lotta contro il rivale",
+            "safariZone": "Visita la Zona Safari",
             "areaZero": "Esplora Area Zero"
           }
+        },
+        "safariZone": {
+          "which": "Quale Pokémon della Zona Safari?"
         },
         "areaZero": {
           "title": "Pokémon Paradosso",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -257,8 +257,12 @@
             "goFishing": "Pescar",
             "findFossil": "Encontrar um Fóssil",
             "battleRival": "Batalha contra o Rival",
+            "safariZone": "Visitar a Zona Safári",
             "areaZero": "Explorar a Área Zero"
           }
+        },
+        "safariZone": {
+          "which": "Qual Pokémon da Zona Safári?"
         },
         "areaZero": {
           "title": "Pokémon Paradoxo",


### PR DESCRIPTION
Closes #44.

Adds a **Safari Zone** slice to the main adventure wheel in Kanto, and first fixes the reason a second region-only slice couldn't be added safely.

## The blocker

The adventure wheel dispatched with `switch (index)`, and Area Zero was appended to the slice array only for generation 9 — so `case 17` meant Area Zero **because exactly one optional slice existed**. Adding a generation-1 slice would have made index 17 mean different things in different regions: a player landing on Find Fossil and getting Safari Zone.

## Slices are now data

`adventure-actions.ts` lists every slice, and `AdventureActionName` is **derived from that list**. The component maps names to outputs through a `Record<AdventureActionName, () => void>`, and dispatch is `this.handlers[this.actions[index].name]()`.

I checked both halves of the guarantee by deliberately breaking them:

| mistake | result |
| --- | --- |
| row added, handler forgotten | `TS2741: Property 'safariZone' is missing in type …` |
| handler for a row that doesn't exist | `TS2561: … 'safariZoneTypo' does not exist in …` |

Strategy expressed as data, matching `POKEMON_POOLS`, `CONSOLATION_PRIZES` and `formRules`. **Decorator was considered and rejected** — the gating axis is set membership (`generations: [1]`), which inheritance can't express without a class per combination.

The other five index-switch roulettes are untouched. None is generation-gated, so none has this bug.

## The wheel

Reuses `PokemonPoolRouletteComponent` as a sixth pool — **no new component**. Area Zero stayed bespoke because its list is generation-*independent*; Safari Zone's is gated to generation 1, which is exactly the pool shape.

**22 species**: the RBY + FRLG Safari Zone table minus the water encounters, which overlap too heavily with the generation 1 fishing wheel.

## Prizes improve as the run goes on

`PokemonPool` gains an optional `rareBoost`, so the seven prizes — Chansey, Kangaskhan, Scyther, Pinsir, Tauros, Dratini, Dragonair — **double in width once `currentRound >= 4`**, the threshold `catch-legendary-roulette` already uses for "past the fourth gym". Three of them have mega forms, so a late Safari trip is worth more than an early one.

⚠️ **The boost clones rather than assigns.** `getPokemonByIdArray` returns the **shared National Dex objects** — writing `.weight` on them would have left Chansey heavier on every other wheel and in the Pokédex for the rest of the session. There's a test asserting the dex entry is untouched.

## Testing

**344 → 368.** The 19 per-slice dispatch tests are what pay for the refactor: an index-based test could never have caught that three slices don't follow the `<name>Event` naming convention (`goStraight` → `doNothingEvent`, `teamRocket` → `teamRocketEncounterEvent`).

Verified in the running app, not just in Karma — the decisive check being that **index 17 fires `areaZeroEvent` in Paldea and `safariZoneEvent` in Kanto**, which is exactly what the old `case 17` could not do:

- Kanto: 18 slices, Safari Zone present, Area Zero absent — and the reverse in Paldea
- Landing on the slice opens the pool wheel titled "Which Safari Zone Pokémon?", all 22 species
- At round 0 every weight is 1; at round 4 the seven prizes are 2 and the National Dex entry for Chansey is still 1

Build 1.50 MB with no budget breached, `npm audit` clean including dev dependencies, all six locales at parity (2,210 keys).

### Worth checking by hand

- Play into Kanto and land on Safari Zone for real — my browser checks drove the component directly, so the wheel's own click path is the gap.
- Land on a few **other** slices in Kanto, Sinnoh and Paldea. That's the regression this refactor exists to prevent, and it's the thing I'd most want a second pair of eyes on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
