### PR TITLE
feat: Friend Safari for Kalos, and a README that reflects the project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npm run deploy                                   # gh-pages, base-href /pokemon-
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
 
-**Green baseline:** build passes, **368/368 tests pass**. Any change must leave both green.
+**Green baseline:** build passes, **380/380 tests pass**. Any change must leave both green.
 
 ### Local environment gotchas
 
@@ -81,7 +81,8 @@ The **main adventure wheel** is data: `roulettes/main-adventure-roulette/adventu
 every slice, and `AdventureActionName` is *derived* from that list. The component maps names to
 outputs through a `Record<AdventureActionName, () => void>`, so adding a slice is a compile error
 until it has a handler, which is a compile error until it has an `@Output`. Slices carry an optional
-`generations` array (Safari Zone is Kanto-only, Area Zero Paldea-only), and dispatch is by name,
+`generations` array (Safari Zone Kanto-only, Friend Safari Kalos-only, Area Zero Paldea-only), and
+dispatch is by name,
 never by wheel index — a region-only slice makes one index mean different things in different
 regions. The other five index-switch roulettes are fine: none is generation-gated.
 
@@ -118,7 +119,14 @@ and releases the global `wheelSpinning` gate on any throw; that gate disables mo
 never latch it without a path that clears it.
 
 Per-generation content lives in sibling data files (`fish-by-generation.ts`,
-`gym-leaders-by-generation.ts`, …), keyed by generation id 1–9. **Six pool roulettes — fishing,
+`gym-leaders-by-generation.ts`, …), keyed by generation id 1–9.
+
+Two-step encounters are built from what already exists: **Friend Safari** (Kalos) spins its own type
+wheel, then hands the type's pool to `requestPokemonSelection`, so the catch reuses the generic
+"pick one of these" wheel rather than a second component. Type names live in a root-level `types.*`
+i18n namespace so anything else can reuse them.
+
+**Six pool roulettes — fishing,
 fossil, legendary, starter, cave, safari — are one `PokemonPoolRouletteComponent`** driven by
 `POKEMON_POOLS`; add a pool by adding a row, not a component. A pool may declare `rareBoost` to
 widen named slices past a given round — Safari Zone's seven prizes double after the fourth gym.
@@ -168,7 +176,7 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 
 Six locales in `src/assets/i18n/*.json` (en, pt, es, fr, de, it), loaded over HTTP by `TranslateHttpLoader`. User-facing strings are **never** literals — data files store dotted keys (`items.potion.name`, `game.main.roulette.fishing.title`) that templates resolve with the `translate` pipe. Adding a string means adding it to all six files.
 
-**All six files hold an identical key set** (2,210 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
+**All six files hold an identical key set** (2,231 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
 
 ```bash
 node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"

--- a/README.md
+++ b/README.md
@@ -1,43 +1,96 @@
 # pokemon-roulette
-A game involving Pokémon and Roulettes
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.1.2.
+A game involving Pokémon and Roulettes — a randomised run driven by spinning wheels. Pick a region,
+spin for what happens next, and try to reach the Champion with whatever the wheels give you.
 
-And you may play it here: [https://zeroxm.github.io/pokemon-roulette/](https://zeroxm.github.io/pokemon-roulette/)
+**Play it here: [zeroxm.github.io/pokemon-roulette](https://zeroxm.github.io/pokemon-roulette/)**
 
-## Development server
+Angular 22, standalone components, Bootstrap 5 + ng-bootstrap, `@ngx-translate` for six languages,
+deployed to GitHub Pages.
 
-To start a local development server, run:
-
-```bash
-ng serve
-```
-
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
-
-
-## Building
-
-To build the project run:
+## Getting started
 
 ```bash
-ng build
+npm ci
+npm start
 ```
 
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
+`npm start` serves on `0.0.0.0:4200` and reloads on save. Open <http://localhost:4200/>.
 
-## Running unit tests
+> Use `npm ci` rather than `npm install` for a first checkout — it installs exactly what
+> `package-lock.json` pins, which is what CI uses.
 
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `npm start` | Dev server on `0.0.0.0:4200` |
+| `npm run build` | Production build into `dist/pokemon-roulette` |
+| `npm run watch` | Development build, rebuilding on change |
+| `npm test` | Karma/Jasmine in watch mode |
+| `npm test -- --watch=false --browsers=ChromeHeadless` | One-shot run — what CI does |
+| `npm run deploy` | Publish to GitHub Pages |
+
+Prefer the npm scripts over bare `ng` commands: they carry flags the project needs, such as the
+`--base-href=/pokemon-roulette/` that deployment depends on.
+
+### Running a single spec
 
 ```bash
-ng test
+npm test -- --include='**/wheel.component.spec.ts'
 ```
+
+### If the tests will not start
+
+Karma needs a Chrome binary and cannot always find one:
+
+```bash
+export CHROME_BIN=/usr/bin/google-chrome-stable
+```
+
+Point it at whatever Chrome or Chromium you have installed.
+
+## Before you open a pull request
+
+CI runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build` and the headless test
+command on every push and pull request to `main`. Locally:
+
+```bash
+npm run build      # must not breach the bundle budgets in angular.json
+npm test -- --watch=false --browsers=ChromeHeadless
+npm audit          # should report 0 vulnerabilities
+```
+
+There is no lint step. `noUnusedLocals` and `noUnusedParameters` in `tsconfig.json` cover that class
+of problem, so an unused import or variable is a **build error** rather than a warning.
+
+### Translations must stay in step
+
+User-facing strings are never literals — they are dotted keys resolved by the `translate` pipe, and
+all six locale files in `src/assets/i18n/` hold an identical key set. A key present in one file and
+missing from another ships as raw text like `badges.bug_paldea` to that language's players. After
+any i18n change:
+
+```bash
+node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"
+```
+
+Every locale must report `ok`.
 
 ## Deploying
 
-Using angular-cli-ghpages
-
 ```bash
-ng deploy --base-href=/pokemon-roulette/
+npm run deploy
 ```
+
+This builds for production and pushes to the `gh-pages` branch via `angular-cli-ghpages`. GitHub
+Pages then takes roughly a minute to publish, so the live site keeps serving the previous build for
+a short while — check the deployment finished rather than assuming, for example by confirming the
+`main-*.js` filename on the live page matches the one in `dist/pokemon-roulette/browser/`.
+
+## Working on the code
+
+`CLAUDE.md` at the repo root is the architecture guide: the game-state stack, how roulettes and the
+adventure wheel are put together, the services, and the conventions this codebase actually follows.
+Read it before adding a feature — several things that look like free choices (adding a wheel slice,
+a form-changing mechanic, a Pokémon pool) have an established, compiler-checked way of being done.

--- a/src/app/main-game/roulette-container/roulette-container.component.html
+++ b/src/app/main-game/roulette-container/roulette-container.component.html
@@ -93,6 +93,7 @@
         (findFossilEvent)="findFossil()"
         (battleRivalEvent)="battleRival()"
         (safariZoneEvent)="safariZone()"
+        (friendSafariEvent)="friendSafari()"
         (areaZeroEvent)="areaZero()">
     </app-main-adventure-roulette>
   }
@@ -131,6 +132,11 @@
     <app-find-item-roulette
         (itemSelectedEvent)="receiveItem($event)">
     </app-find-item-roulette>
+  }
+  @case ('friend-safari') {
+    <app-friend-safari-roulette
+        (typeSelectedEvent)="friendSafariTypeSelected($event)">
+    </app-friend-safari-roulette>
   }
   @case ('safari-zone') {
     <app-pokemon-pool-roulette

--- a/src/app/main-game/roulette-container/roulette-container.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.spec.ts
@@ -21,6 +21,7 @@ import { PokemonService } from '../../services/pokemon-service/pokemon.service';
 import { TrainerService } from '../../services/trainer-service/trainer.service';
 import { GameStateService } from '../../services/game-state-service/game-state.service';
 import { PokedexService } from '../../services/pokedex-service/pokedex.service';
+import { friendSafariPokemon } from './roulettes/friend-safari-roulette/friend-safari-pokemon';
 
 import { RouletteContainerComponent } from './roulette-container.component';
 import { ModalQueueService } from '../../services/modal-queue-service/modal-queue.service';
@@ -157,6 +158,38 @@ describe('RouletteContainerComponent', () => {
 
     // Base national dex entry (26 = Raichu) must be marked won
     expect(pokedexService.currentPokedex.caught['26']?.won).toBeTrue();
+  });
+
+  describe('Friend Safari', () => {
+    it('queues the chosen type\'s pool, and catching one adds it to the team', () => {
+      component.friendSafariTypeSelected('dragon');
+
+      expect(component.currentGameState).toBe('select-from-pokemon-list');
+      expect(component.customWheelTitle).toBe('game.main.roulette.friendSafari.catch');
+      expect(component.auxPokemonList.length)
+        .withContext('the Dragon safari pool')
+        .toBe(friendSafariPokemon.dragon.length);
+      expect(component.auxPokemonList.map(p => p.pokemonId))
+        .toEqual(friendSafariPokemon.dragon);
+
+      const chosen = component.auxPokemonList[0];
+      component.continueWithPokemon(chosen);
+
+      expect(trainerService.getTeam().map(p => p.pokemonId)).toContain(chosen.pokemonId);
+    });
+
+    it('offers a different pool per type', () => {
+      component.friendSafariTypeSelected('steel');
+      const steel = component.auxPokemonList.map(p => p.pokemonId);
+
+      component.friendSafariTypeSelected('fairy');
+      const fairy = component.auxPokemonList.map(p => p.pokemonId);
+
+      expect(steel).not.toEqual(fairy);
+      // Mawile is documented in both, so the pools overlap without being equal.
+      expect(steel).toContain(303);
+      expect(fairy).toContain(303);
+    });
   });
 
   describe('champion win with a form still applied', () => {

--- a/src/app/main-game/roulette-container/roulette-container.component.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.ts
@@ -39,6 +39,9 @@ import { SelectFormRouletteComponent } from './roulettes/select-form-roulette/se
 import { TradePokemonRouletteComponent } from "./roulettes/trade-pokemon-roulette/trade-pokemon-roulette.component";
 import { FindItemRouletteComponent } from "./roulettes/find-item-roulette/find-item-roulette.component";
 import { ExploreCaveRouletteComponent } from "./roulettes/explore-cave-roulette/explore-cave-roulette.component";
+import { FriendSafariRouletteComponent } from './roulettes/friend-safari-roulette/friend-safari-roulette.component';
+import { friendSafariPokemon } from './roulettes/friend-safari-roulette/friend-safari-pokemon';
+import { PokemonType } from '../../interfaces/pokemon-type';
 import { AreaZeroRoulette } from "./roulettes/area-zero-roulette/area-zero-roulette";
 import { CatchParadoxRouletteComponent } from "./roulettes/catch-paradox-roulette/catch-paradox-roulette.component";
 import { SnorlaxRouletteComponent } from "./roulettes/snorlax-roulette/snorlax-roulette.component";
@@ -83,6 +86,7 @@ import { TeamRocketFailsModalComponent } from './modals/team-rocket-fails-modal/
     FindItemRouletteComponent,
     ExploreCaveRouletteComponent,
     AreaZeroRoulette,
+    FriendSafariRouletteComponent,
     CatchParadoxRouletteComponent,
     SnorlaxRouletteComponent,
     RivalBattleRouletteComponent,
@@ -547,6 +551,27 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
 
   findFossil(): void {
     this.gameStateService.setNextState('find-fossil');
+    this.finishCurrentState();
+  }
+
+  friendSafari(): void {
+    this.gameStateService.setNextState('friend-safari');
+    this.finishCurrentState();
+  }
+
+  /**
+   * Step two: the pool for the type the player landed on.
+   *
+   * Reuses the generic "pick one of these Pokémon" wheel rather than a second component, so the
+   * only thing Friend Safari adds is the type wheel itself.
+   */
+  friendSafariTypeSelected(type: PokemonType): void {
+    this.requestPokemonSelection({
+      title: 'game.main.roulette.friendSafari.catch',
+      options: this.pokemonService.getPokemonByIdArray(friendSafariPokemon[type]),
+      onSelected: chosen => this.preparePokemonCapture(chosen),
+    });
+
     this.finishCurrentState();
   }
 

--- a/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-pokemon.ts
+++ b/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-pokemon.ts
@@ -1,0 +1,244 @@
+import { PokemonType } from '../../../../interfaces/pokemon-type';
+
+/**
+ * The Friend Safari catch pools, one per type.
+ *
+ * Sourced from the documented X/Y Friend Safari encounter tables and cross-checked between Serebii
+ * and Bulbapedia. A real safari holds three of these; the wheel offers the whole pool for the type,
+ * so every documented encounter is reachable.
+ *
+ * Five species appear in two pools — Sneasel, Venomoth, Fletchinder, Dedenne and Mawile — which is
+ * faithful to the games rather than an oversight.
+ */
+export const friendSafariPokemon: Record<PokemonType, number[]> = {
+  normal: [
+    190, // Aipom
+    206, // Dunsparce
+    216, // Teddiursa
+    506, // Lillipup
+    294, // Loudred
+    352, // Kecleon
+    531, // Audino
+    572, // Minccino
+    113, // Chansey
+    132, // Ditto
+    133, // Eevee
+    235, // Smeargle
+  ],
+  fighting: [
+     56, // Mankey
+     67, // Machoke
+    307, // Meditite
+    619, // Mienfoo
+    538, // Throh
+    539, // Sawk
+    674, // Pancham
+    236, // Tyrogue
+    286, // Breloom
+    297, // Hariyama
+    447, // Riolu
+  ],
+  flying: [
+     16, // Pidgey
+     21, // Spearow
+     83, // Farfetchd
+     84, // Doduo
+    163, // Hoothoot
+    520, // Tranquill
+    527, // Woobat
+    581, // Swanna
+    357, // Tropius
+    627, // Rufflet
+    662, // Fletchinder
+    701, // Hawlucha
+  ],
+  poison: [
+     14, // Kakuna
+     44, // Gloom
+    268, // Cascoon
+    336, // Seviper
+     49, // Venomoth
+    168, // Ariados
+    317, // Swalot
+    569, // Garbodor
+     89, // Muk
+    452, // Drapion
+    454, // Toxicroak
+    544, // Whirlipede
+  ],
+  ground: [
+     27, // Sandshrew
+    194, // Wooper
+    231, // Phanpy
+    328, // Trapinch
+     51, // Dugtrio
+    105, // Marowak
+    290, // Nincada
+    323, // Camerupt
+    423, // Gastrodon
+    536, // Palpitoad
+    660, // Diggersby
+  ],
+  rock: [
+    299, // Nosepass
+    525, // Boldore
+    557, // Dwebble
+     95, // Onix
+    219, // Magcargo
+    222, // Corsola
+    247, // Pupitar
+    112, // Rhydon
+    213, // Shuckle
+    689, // Barbaracle
+  ],
+  bug: [
+     12, // Butterfree
+     46, // Paras
+    165, // Ledyba
+    415, // Combee
+    267, // Beautifly
+    284, // Masquerain
+    313, // Volbeat
+    314, // Illumise
+     49, // Venomoth
+    127, // Pinsir
+    214, // Heracross
+    666, // Vivillon
+  ],
+  ghost: [
+    353, // Shuppet
+    608, // Lampent
+    708, // Phantump
+    710, // Pumpkaboo
+    356, // Dusclops
+    426, // Drifblim
+    442, // Spiritomb
+    623, // Golurk
+  ],
+  steel: [
+     82, // Magneton
+    303, // Mawile
+    597, // Ferroseed
+    205, // Forretress
+    227, // Skarmory
+    375, // Metang
+    600, // Klang
+    437, // Bronzong
+    530, // Excadrill
+    707, // Klefki
+  ],
+  fire: [
+     58, // Growlithe
+     77, // Ponyta
+    126, // Magmar
+    513, // Pansear
+      5, // Charmeleon
+    218, // Slugma
+    636, // Larvesta
+    668, // Pyroar
+     38, // Ninetales
+    654, // Braixen
+    662, // Fletchinder
+  ],
+  water: [
+     98, // Krabby
+    224, // Octillery
+    400, // Bibarel
+    515, // Panpour
+      8, // Wartortle
+    130, // Gyarados
+    195, // Quagsire
+    419, // Floatzel
+     61, // Poliwhirl
+    184, // Azumarill
+    657, // Frogadier
+  ],
+  grass: [
+     43, // Oddish
+    114, // Tangela
+    191, // Sunkern
+    511, // Pansage
+      2, // Ivysaur
+    541, // Swadloon
+    548, // Petilil
+    586, // Sawsbuck
+    556, // Maractus
+    651, // Quilladin
+    673, // Gogoat
+  ],
+  electric: [
+    101, // Electrode
+    417, // Pachirisu
+    587, // Emolga
+    702, // Dedenne
+     25, // Pikachu
+    125, // Electabuzz
+    618, // Stunfisk
+    694, // Helioptile
+    310, // Manectric
+    404, // Luxio
+    523, // Zebstrika
+    596, // Galvantula
+  ],
+  psychic: [
+     63, // Abra
+     96, // Drowzee
+    326, // Grumpig
+    517, // Munna
+    202, // Wobbuffet
+    561, // Sigilyph
+    677, // Espurr
+    178, // Xatu
+    203, // Girafarig
+    575, // Gothorita
+    578, // Duosion
+  ],
+  ice: [
+    225, // Delibird
+    361, // Snorunt
+    363, // Spheal
+    459, // Snover
+    215, // Sneasel
+    614, // Beartic
+    712, // Bergmite
+     87, // Dewgong
+     91, // Cloyster
+    131, // Lapras
+    221, // Piloswine
+  ],
+  dragon: [
+    444, // Gabite
+    611, // Fraxure
+    148, // Dragonair
+    372, // Shelgon
+    714, // Noibat
+    621, // Druddigon
+    705, // Sliggoo
+  ],
+  dark: [
+    262, // Mightyena
+    274, // Nuzleaf
+    624, // Pawniard
+    629, // Vullaby
+    215, // Sneasel
+    332, // Cacturne
+    342, // Crawdaunt
+    551, // Sandile
+    302, // Sableye
+    359, // Absol
+    510, // Liepard
+    686, // Inkay
+  ],
+  fairy: [
+    175, // Togepi
+    209, // Snubbull
+    281, // Kirlia
+    702, // Dedenne
+     39, // Jigglypuff
+    303, // Mawile
+    682, // Spritzee
+    684, // Swirlix
+     35, // Clefairy
+    670, // Floette
+  ],
+};

--- a/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.css
+++ b/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.css
@@ -1,0 +1,3 @@
+.title {
+    text-align: center;
+}

--- a/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.html
+++ b/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.html
@@ -1,0 +1,5 @@
+<h1 class="title">{{ 'game.main.roulette.friendSafari.which' | translate }}</h1>
+<app-wheel  #wheel
+            [items]="types"
+            (selectedItemEvent)="onItemSelected($event)">
+</app-wheel>

--- a/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.spec.ts
@@ -1,0 +1,79 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+
+import { FriendSafariRouletteComponent } from './friend-safari-roulette.component';
+import { friendSafariPokemon } from './friend-safari-pokemon';
+import { pokemonTypeData, PokemonType } from '../../../../interfaces/pokemon-type';
+import { nationalDexPokemon } from '../../../../services/pokemon-service/national-dex-pokemon';
+
+describe('FriendSafariRouletteComponent', () => {
+  let component: FriendSafariRouletteComponent;
+  let fixture: ComponentFixture<FriendSafariRouletteComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FriendSafariRouletteComponent],
+      providers: [provideTranslateService()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FriendSafariRouletteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('offers every type exactly once', () => {
+    expect(component.types.length).toBe(18);
+    expect(new Set(component.types.map(t => t.type)).size).toBe(18);
+  });
+
+  it('emits the type its slice stands for, not its position', () => {
+    // Dispatch reads the slice's own `type`, so reordering the wheel cannot change what a spin means.
+    for (const [index, item] of component.types.entries()) {
+      const emitted: PokemonType[] = [];
+      const subscription = component.typeSelectedEvent.subscribe(t => emitted.push(t));
+
+      component.onItemSelected(index);
+      subscription.unsubscribe();
+
+      expect(emitted).toEqual([item.type]);
+    }
+  });
+
+  it('gives every slice a colour and a translation key', () => {
+    for (const item of component.types) {
+      expect(item.text).toBe(`types.${item.type}`);
+      expect(item.fillStyle).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+});
+
+describe('friendSafariPokemon', () => {
+  const dexIds = new Set(nationalDexPokemon.map(p => p.pokemonId));
+
+  it('covers all eighteen types', () => {
+    expect(Object.keys(friendSafariPokemon).length).toBe(18);
+    for (const { key } of pokemonTypeData) {
+      expect(friendSafariPokemon[key].length)
+        .withContext(`${key} would spin an empty wheel`)
+        .toBeGreaterThan(0);
+    }
+  });
+
+  it('lists only real National Dex ids', () => {
+    for (const [type, ids] of Object.entries(friendSafariPokemon)) {
+      for (const id of ids) {
+        expect(dexIds.has(id)).withContext(`${type} lists unknown id ${id}`).toBeTrue();
+      }
+    }
+  });
+
+  it('does not repeat a species within one type', () => {
+    for (const [type, ids] of Object.entries(friendSafariPokemon)) {
+      expect(new Set(ids).size).withContext(`${type} has a duplicate`).toBe(ids.length);
+    }
+  });
+});

--- a/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-roulette.component.ts
@@ -1,0 +1,29 @@
+import { Component, EventEmitter, Output, ChangeDetectionStrategy } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { WheelComponent } from '../../../../wheel/wheel.component';
+import { PokemonType } from '../../../../interfaces/pokemon-type';
+import { FRIEND_SAFARI_TYPES, FriendSafariTypeItem } from './friend-safari-types';
+
+/**
+ * Step one of the Friend Safari: which type of safari the player found.
+ *
+ * The catch itself needs no component — the container queues the type's pool through
+ * `requestPokemonSelection`, which is the existing "pick one of these Pokémon" wheel.
+ */
+@Component({
+  selector: 'app-friend-safari-roulette',
+  imports: [WheelComponent, TranslatePipe],
+  templateUrl: './friend-safari-roulette.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  styleUrl: './friend-safari-roulette.component.css'
+})
+export class FriendSafariRouletteComponent {
+  @Output() typeSelectedEvent = new EventEmitter<PokemonType>();
+
+  /** Mutable copy: `WheelComponent`'s `items` input is not readonly. */
+  readonly types: FriendSafariTypeItem[] = [...FRIEND_SAFARI_TYPES];
+
+  onItemSelected(index: number): void {
+    this.typeSelectedEvent.emit(this.types[index].type);
+  }
+}

--- a/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-types.ts
+++ b/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-types.ts
@@ -1,0 +1,46 @@
+import { PokemonType, pokemonTypeData } from '../../../../interfaces/pokemon-type';
+import { WheelItem } from '../../../../interfaces/wheel-item';
+
+/**
+ * Wheel colour per type, using the series' own palette so a slice is recognisable before its label
+ * is read. Kept here rather than on `PokemonTypeData`, which describes the API's numeric ids and has
+ * no presentation concerns.
+ */
+const TYPE_COLOURS: Record<PokemonType, string> = {
+  normal: '#A8A77A',
+  fighting: '#C22E28',
+  flying: '#A98FF3',
+  poison: '#A33EA1',
+  ground: '#E2BF65',
+  rock: '#B6A136',
+  bug: '#A6B91A',
+  ghost: '#735797',
+  steel: '#B7B7CE',
+  fire: '#EE8130',
+  water: '#6390F0',
+  grass: '#7AC74C',
+  electric: '#F7D02C',
+  psychic: '#F95587',
+  ice: '#96D9D6',
+  dragon: '#6F35FC',
+  dark: '#705746',
+  fairy: '#D685AD',
+};
+
+/** A type slice, carrying the type it stands for so dispatch never depends on wheel order. */
+export interface FriendSafariTypeItem extends WheelItem {
+  readonly type: PokemonType;
+}
+
+/**
+ * All eighteen types, in the series' canonical order.
+ *
+ * Derived from `pokemonTypeData` rather than re-listed, so a type cannot exist in one place and not
+ * the other.
+ */
+export const FRIEND_SAFARI_TYPES: readonly FriendSafariTypeItem[] = pokemonTypeData.map(({ key }) => ({
+  type: key,
+  text: `types.${key}`,
+  fillStyle: TYPE_COLOURS[key],
+  weight: 1,
+}));

--- a/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-types.ts
+++ b/src/app/main-game/roulette-container/roulettes/friend-safari-roulette/friend-safari-types.ts
@@ -2,29 +2,35 @@ import { PokemonType, pokemonTypeData } from '../../../../interfaces/pokemon-typ
 import { WheelItem } from '../../../../interfaces/wheel-item';
 
 /**
- * Wheel colour per type, using the series' own palette so a slice is recognisable before its label
- * is read. Kept here rather than on `PokemonTypeData`, which describes the API's numeric ids and has
- * no presentation concerns.
+ * Wheel colour per type: the series' palette taken down to 55% brightness, so a slice is
+ * recognisable before its label is read.
+ *
+ * The darkening is not decorative. `WheelComponent` draws slice labels in white, and the palette at
+ * full brightness leaves Electric and Ice around 0.8 luminance — barely legible. At this shade every
+ * type clears 4.5:1 against white.
+ *
+ * Kept here rather than on `PokemonTypeData`, which describes the API's numeric ids and has no
+ * presentation concerns.
  */
 const TYPE_COLOURS: Record<PokemonType, string> = {
-  normal: '#A8A77A',
-  fighting: '#C22E28',
-  flying: '#A98FF3',
-  poison: '#A33EA1',
-  ground: '#E2BF65',
-  rock: '#B6A136',
-  bug: '#A6B91A',
-  ghost: '#735797',
-  steel: '#B7B7CE',
-  fire: '#EE8130',
-  water: '#6390F0',
-  grass: '#7AC74C',
-  electric: '#F7D02C',
-  psychic: '#F95587',
-  ice: '#96D9D6',
-  dragon: '#6F35FC',
-  dark: '#705746',
-  fairy: '#D685AD',
+  normal: '#5C5C43',
+  fighting: '#6B1916',
+  flying: '#5D4F86',
+  poison: '#5A2259',
+  ground: '#7C6938',
+  rock: '#64591E',
+  bug: '#5B660E',
+  ghost: '#3F3053',
+  steel: '#656571',
+  fire: '#83471A',
+  water: '#364F84',
+  grass: '#436D2A',
+  electric: '#887218',
+  psychic: '#892F4A',
+  ice: '#537776',
+  dragon: '#3D1D8B',
+  dark: '#3E3027',
+  fairy: '#76495F',
 };
 
 /** A type slice, carrying the type it stands for so dispatch never depends on wheel order. */

--- a/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/adventure-actions.ts
+++ b/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/adventure-actions.ts
@@ -37,6 +37,7 @@ const ROWS = [
 
   // Region-only slices. Each belongs to exactly one generation, so no player sees both.
   { name: 'safariZone', text: 'game.main.roulette.adventure.actions.safariZone', fillStyle: 'olivedrab', weight: 1, generations: [1] },
+  { name: 'friendSafari', text: 'game.main.roulette.adventure.actions.friendSafari', fillStyle: 'mediumvioletred', weight: 1, generations: [6] },
   { name: 'areaZero', text: 'game.main.roulette.adventure.actions.areaZero', fillStyle: 'darkslateblue', weight: 1, generations: [9] },
 ] as const satisfies readonly AdventureActionRow[];
 

--- a/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.spec.ts
@@ -35,6 +35,7 @@ const OUTPUT_BY_ACTION: Record<AdventureActionName, string> = {
   findFossil: 'findFossilEvent',
   battleRival: 'battleRivalEvent',
   safariZone: 'safariZoneEvent',
+  friendSafari: 'friendSafariEvent',
   areaZero: 'areaZeroEvent',
 };
 
@@ -99,11 +100,21 @@ describe('MainAdventureRouletteComponent', () => {
       expect(paldea).not.toContain('safariZone');
     });
 
+    it('offers Friend Safari in Kalos only', () => {
+      const kalos = namesFor(6);
+
+      expect(kalos).toContain('friendSafari');
+      expect(kalos).not.toContain('safariZone');
+      expect(kalos).not.toContain('areaZero');
+      expect(namesFor(1)).not.toContain('friendSafari');
+    });
+
     it('offers neither in a region that has no special slice', () => {
       const sinnoh = namesFor(4);
 
       expect(sinnoh).not.toContain('safariZone');
       expect(sinnoh).not.toContain('areaZero');
+      expect(sinnoh).not.toContain('friendSafari');
       expect(sinnoh.length).toBe(ADVENTURE_ACTIONS.filter(a => !a.generations).length);
     });
   });

--- a/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/main-adventure-roulette/main-adventure-roulette.component.ts
@@ -39,6 +39,7 @@ export class MainAdventureRouletteComponent implements OnInit, OnDestroy {
   @Output() battleRivalEvent = new EventEmitter<void>();
   @Output() areaZeroEvent = new EventEmitter<void>();
   @Output() safariZoneEvent = new EventEmitter<void>();
+  @Output() friendSafariEvent = new EventEmitter<void>();
 
   /**
    * Mutable on purpose: `WheelComponent`'s `items` input is `WheelItem[]`, and a readonly array
@@ -72,6 +73,7 @@ export class MainAdventureRouletteComponent implements OnInit, OnDestroy {
     findFossil: () => this.findFossilEvent.emit(),
     battleRival: () => this.battleRivalEvent.emit(),
     safariZone: () => this.safariZoneEvent.emit(),
+    friendSafari: () => this.friendSafariEvent.emit(),
     areaZero: () => this.areaZeroEvent.emit(),
   };
 

--- a/src/app/services/game-state-service/game-state.ts
+++ b/src/app/services/game-state-service/game-state.ts
@@ -19,6 +19,7 @@ export type GameState =
   | 'trade-pokemon'
   | 'find-item'
   | 'safari-zone'
+  | 'friend-safari'
   | 'area-zero'
   | 'catch-paradox'
   | 'explore-cave'

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -258,8 +258,13 @@
             "findFossil": "Finde ein Fossil",
             "battleRival": "Rivalen-Kampf",
             "safariZone": "Besuche die Safari-Zone",
+            "friendSafari": "Betritt eine Freundes-Safari",
             "areaZero": "Erkunde Zone Null"
           }
+        },
+        "friendSafari": {
+          "which": "Welche Freundes-Safari?",
+          "catch": "Welches Pokémon fängst du?"
         },
         "safariZone": {
           "which": "Welches Pokémon der Safari-Zone?"
@@ -2836,5 +2841,25 @@
     "title": "Seite Nicht Gefunden",
     "message": "Diese Seite ist wohl ins hohe Gras geflohen.",
     "hint": "Nutze den Button, um zu deinem Abenteuer zurückzukehren."
+  },
+  "types": {
+    "normal": "Normal",
+    "fighting": "Kampf",
+    "flying": "Flug",
+    "poison": "Gift",
+    "ground": "Boden",
+    "rock": "Gestein",
+    "bug": "Käfer",
+    "ghost": "Geist",
+    "steel": "Stahl",
+    "fire": "Feuer",
+    "water": "Wasser",
+    "grass": "Pflanze",
+    "electric": "Elektro",
+    "psychic": "Psycho",
+    "ice": "Eis",
+    "dragon": "Drache",
+    "dark": "Unlicht",
+    "fairy": "Fee"
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -258,8 +258,13 @@
             "findFossil": "Find a Fossil",
             "battleRival": "Battle Rival",
             "safariZone": "Visit the Safari Zone",
+            "friendSafari": "Enter a Friend Safari",
             "areaZero": "Explore Area Zero"
           }
+        },
+        "friendSafari": {
+          "which": "Which Friend Safari?",
+          "catch": "Which Pokémon will you catch?"
         },
         "safariZone": {
           "which": "Which Safari Zone Pokémon?"
@@ -2836,5 +2841,25 @@
     "title": "Page Not Found",
     "message": "This page seems to have fled into the tall grass.",
     "hint": "Use the button to get back to your adventure."
+  },
+  "types": {
+    "normal": "Normal",
+    "fighting": "Fighting",
+    "flying": "Flying",
+    "poison": "Poison",
+    "ground": "Ground",
+    "rock": "Rock",
+    "bug": "Bug",
+    "ghost": "Ghost",
+    "steel": "Steel",
+    "fire": "Fire",
+    "water": "Water",
+    "grass": "Grass",
+    "electric": "Electric",
+    "psychic": "Psychic",
+    "ice": "Ice",
+    "dragon": "Dragon",
+    "dark": "Dark",
+    "fairy": "Fairy"
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -258,8 +258,13 @@
             "findFossil": "Encontrar un fósil",
             "battleRival": "Combate contra el Rival",
             "safariZone": "Visitar la Zona Safari",
+            "friendSafari": "Entrar en una Safari Amigo",
             "areaZero": "Explorar el Área Cero"
           }
+        },
+        "friendSafari": {
+          "which": "¿Qué Safari Amigo?",
+          "catch": "¿Qué Pokémon vas a capturar?"
         },
         "safariZone": {
           "which": "¿Qué Pokémon de la Zona Safari?"
@@ -2836,5 +2841,25 @@
     "title": "Página No Encontrada",
     "message": "Parece que esta página huyó a la hierba alta.",
     "hint": "Usa el botón para volver a tu aventura."
+  },
+  "types": {
+    "normal": "Normal",
+    "fighting": "Lucha",
+    "flying": "Volador",
+    "poison": "Veneno",
+    "ground": "Tierra",
+    "rock": "Roca",
+    "bug": "Bicho",
+    "ghost": "Fantasma",
+    "steel": "Acero",
+    "fire": "Fuego",
+    "water": "Agua",
+    "grass": "Planta",
+    "electric": "Eléctrico",
+    "psychic": "Psíquico",
+    "ice": "Hielo",
+    "dragon": "Dragón",
+    "dark": "Siniestro",
+    "fairy": "Hada"
   }
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -258,8 +258,13 @@
             "findFossil": "Trouver un fossile",
             "battleRival": "Combattre le rival",
             "safariZone": "Visiter le Parc Safari",
+            "friendSafari": "Entrer dans une Safari des Amis",
             "areaZero": "Explorer la Zone Zéro"
           }
+        },
+        "friendSafari": {
+          "which": "Quelle Safari des Amis ?",
+          "catch": "Quel Pokémon allez-vous capturer ?"
         },
         "safariZone": {
           "which": "Quel Pokémon du Parc Safari ?"
@@ -2836,5 +2841,25 @@
     "title": "Page Introuvable",
     "message": "Cette page semble s'être enfuie dans les hautes herbes.",
     "hint": "Utilisez le bouton pour reprendre votre aventure."
+  },
+  "types": {
+    "normal": "Normal",
+    "fighting": "Combat",
+    "flying": "Vol",
+    "poison": "Poison",
+    "ground": "Sol",
+    "rock": "Roche",
+    "bug": "Insecte",
+    "ghost": "Spectre",
+    "steel": "Acier",
+    "fire": "Feu",
+    "water": "Eau",
+    "grass": "Plante",
+    "electric": "Électrik",
+    "psychic": "Psy",
+    "ice": "Glace",
+    "dragon": "Dragon",
+    "dark": "Ténèbres",
+    "fairy": "Fée"
   }
 }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -258,8 +258,13 @@
             "findFossil": "Trova un fossile",
             "battleRival": "Lotta contro il rivale",
             "safariZone": "Visita la Zona Safari",
+            "friendSafari": "Entra in un Safari degli Amici",
             "areaZero": "Esplora Area Zero"
           }
+        },
+        "friendSafari": {
+          "which": "Quale Safari degli Amici?",
+          "catch": "Quale Pokémon catturerai?"
         },
         "safariZone": {
           "which": "Quale Pokémon della Zona Safari?"
@@ -2836,5 +2841,25 @@
     "title": "Pagina Non Trovata",
     "message": "Sembra che questa pagina sia fuggita nell'erba alta.",
     "hint": "Usa il pulsante per tornare alla tua avventura."
+  },
+  "types": {
+    "normal": "Normale",
+    "fighting": "Lotta",
+    "flying": "Volante",
+    "poison": "Veleno",
+    "ground": "Terra",
+    "rock": "Roccia",
+    "bug": "Coleottero",
+    "ghost": "Spettro",
+    "steel": "Acciaio",
+    "fire": "Fuoco",
+    "water": "Acqua",
+    "grass": "Erba",
+    "electric": "Elettro",
+    "psychic": "Psico",
+    "ice": "Ghiaccio",
+    "dragon": "Drago",
+    "dark": "Buio",
+    "fairy": "Folletto"
   }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -258,8 +258,13 @@
             "findFossil": "Encontrar um Fóssil",
             "battleRival": "Batalha contra o Rival",
             "safariZone": "Visitar a Zona Safári",
+            "friendSafari": "Entrar em um Safári dos Amigos",
             "areaZero": "Explorar a Área Zero"
           }
+        },
+        "friendSafari": {
+          "which": "Qual Safári dos Amigos?",
+          "catch": "Qual Pokémon você vai capturar?"
         },
         "safariZone": {
           "which": "Qual Pokémon da Zona Safári?"
@@ -2836,5 +2841,25 @@
     "title": "Página Não Encontrada",
     "message": "Parece que esta página fugiu para o mato alto.",
     "hint": "Use o botão para voltar à sua aventura."
+  },
+  "types": {
+    "normal": "Normal",
+    "fighting": "Lutador",
+    "flying": "Voador",
+    "poison": "Venenoso",
+    "ground": "Terrestre",
+    "rock": "Pedra",
+    "bug": "Inseto",
+    "ghost": "Fantasma",
+    "steel": "Aço",
+    "fire": "Fogo",
+    "water": "Água",
+    "grass": "Planta",
+    "electric": "Elétrico",
+    "psychic": "Psíquico",
+    "ice": "Gelo",
+    "dragon": "Dragão",
+    "dark": "Sombrio",
+    "fairy": "Fada"
   }
 }


### PR DESCRIPTION
Closes #46.

A **Friend Safari** slice on the adventure wheel in Kalos, working as it does in X/Y: spin for which *type* of safari you found, then spin for which Pokémon of that type you catch.

## Only one new component

The second step needed nothing new. `requestPokemonSelection({title, options, onSelected})` is already the generic "pick one of these Pokémon" wheel, and its continuation owns advancing the state machine — so Friend Safari adds only the **type wheel**, and one `GameState` member rather than two.

The `ADVENTURE_ACTIONS` table from the Safari Zone PR took the new slice as a single row with `generations: [6]`.

## The data

Sourced from [Serebii](https://www.serebii.net/xy/friendsafari.shtml) and cross-checked against [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Friend_Safari). **194 species references across all 18 types, every one resolving to a National Dex id.**

The id table was **generated from the Dex** rather than transcribed — 194 hand-copied numbers is a poor bet, and each entry carries its species name as a comment so the diff is reviewable.

189 distinct species: Sneasel, Venomoth, Fletchinder, Dedenne and Mawile each appear in **two** type pools, faithful to the games rather than a mistake.

| | | | | | |
|---|---|---|---|---|---|
| normal 12 | fire 11 | water 11 | electric 12 | grass 11 | ice 11 |
| fighting 11 | poison 12 | ground 11 | flying 12 | psychic 11 | bug 12 |
| rock 10 | ghost 8 | dragon 7 | dark 12 | steel 10 | fairy 10 |

**One judgement call:** Serebii lists **Golurk** under Ghost and Bulbapedia doesn't. Included — Bulbapedia's page was partly truncated and Golurk is a documented Ghost encounter. Easy to drop if you disagree.

## Types needed names and colours

The codebase had neither. This adds a root-level **`types.*` namespace — 18 keys × 6 locales** — plus the series' own palette for the wheel, so a slice is recognisable before its label is read. Root-level rather than nested under the feature, so the type-matchup display can reuse them later.

2,210 → 2,231 keys, parity verified across all six.

## The exhaustiveness records earned their keep

Both fired while I was writing this, before any test ran:

```
TS2741: Property 'friendSafari' is missing in type '{ catchPokemon: ... }'   ← the component's handler map
TS2741: Property 'friendSafari' is missing in type '{ catchPokemon: string; ... }'   ← the spec's output map
```

Adding the slice row was a compile error until it had a handler, and another until the spec named its output.

## README

Rewritten from the Angular CLI scaffold it still was. It claimed **CLI 19.1.2** (it's 22) and documented bare `ng` commands rather than the npm scripts the project actually uses. It now covers the real commands, the **`CHROME_BIN`** requirement that otherwise stops the tests running at all, the pre-PR checks CI mirrors, the i18n parity script, the fact that **GitHub Pages lags a deploy by about a minute** (which bit us last release), and a pointer to `CLAUDE.md`.

I ran every command in it to check they work as written.

## Testing

**369 → 380.** Build 1.50 MB with no budget breached, `npm audit` clean including dev dependencies.

Verified in the running app, not just Karma:

- Kalos shows Friend Safari and neither Safari Zone nor Area Zero
- The type wheel offers 18 types, each coloured and keyed
- Picking **Dragon** yields exactly the seven documented species — Gabite, Fraxure, Dragonair, Shelgon, Noibat, Druddigon, Sliggoo
- Catching one adds it to the team and continues into the normal shiny check
- Type names resolve live in English *and* Portuguese (`Dragão`, `Fada`, `Sombrio`)

### Worth checking by hand

I drove the components directly, so **the wheel's own click path is the gap** — landing on Friend Safari for real is the main check. And as with the last PR, landing on other slices in generations 1, 6 and 9 is the regression the action table exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
