### PR TITLE
StatsService: lifetime counters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,12 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 - `ModalQueueService` — serializes `NgbModal` opens so chained result modals don't stomp each other. Prefer it over `NgbModal` directly for anything the game flow triggers.
 - `SoundFxService` — `playSoundFx('click')`; sounds are named by a `SoundFxName` union, not by per-caller handles. Honors the mute setting.
 - `SettingsService` / `ThemeService` — persisted to `localStorage` (`pokemon-roulette-settings`, `pokemon-roulette-theme`).
+- `StatsService` — lifetime counters, persisted to `pokemon-roulette-stats`. **The counter names are
+  the wire format**: they are exactly the keys the backend accepts, so a blob syncs without
+  translation, and adding one means adding it to the backend's allowlist too (backend first, or the
+  key is skipped until it deploys). Counters are **grow-only** — a non-positive increment is ignored
+  rather than applied. It deliberately does *not* count distinct caught, shinies or megas: those are
+  derived from `PokedexService`, and duplicating them would create two versions of one truth.
 - `PokedexService`, `BadgesService`, `EvolutionService`, `TypeMatchupService`, `AnalyticsService` (GA id in `src/environments/`).
 
 ### i18n

--- a/src/app/services/stats-service/counter-keys.ts
+++ b/src/app/services/stats-service/counter-keys.ts
@@ -1,0 +1,76 @@
+/**
+ * Lifetime counters the game keeps.
+ *
+ * These names are the wire format: they are exactly the keys the backend
+ * accepts, so a stats blob syncs without translation. The backend rejects
+ * anything not on this list, which is what stops a typo becoming a counter
+ * that silently never moves.
+ *
+ * Adding a counter means adding it here *and* to the backend's allowlist.
+ * The backend must ship first, or the new key is skipped until it does —
+ * skipped, not lost: the client sends absolute state, so it lands on the next
+ * sync after the backend learns it.
+ */
+export const FIXED_COUNTER_KEYS = [
+  'runs_completed',
+  'spins_total',
+  'rival_battles_won',
+  'champion_with_six',
+  'champion_with_three_or_fewer',
+  'mimikyu_disguises_busted',
+  'ash_greninja_transformations',
+  'sticky_forms_triggered',
+  'fishing_catches',
+  'fossil_catches',
+  'team_rocket_defeats',
+  'team_rocket_rescues',
+  'eggs_hatched',
+  'snorlax_resolved',
+  'safari_zone_visits',
+  'friend_safari_visits',
+  'area_zero_visits',
+  'trades_completed',
+] as const;
+
+export type FixedCounterKey = typeof FIXED_COUNTER_KEYS[number];
+
+/** Generation ids, as used everywhere else in the game. */
+export type GenerationId = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+export const GENERATION_IDS: readonly GenerationId[] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+/**
+ * Per-region counters. `champion_region:4` counts how many times Sinnoh has
+ * been beaten, so "have I beaten Sinnoh" is `> 0` and "how many regions" is a
+ * count of keys above zero.
+ *
+ * A counter rather than a set because it is genuinely a count, and because it
+ * then merges by the same rule as everything else.
+ */
+export type RegionCounterKey =
+  | `champion_region:${GenerationId}`
+  | `played_region:${GenerationId}`;
+
+export type CounterKey = FixedCounterKey | RegionCounterKey;
+
+export function championRegionKey(generation: GenerationId): RegionCounterKey {
+  return `champion_region:${generation}`;
+}
+
+export function playedRegionKey(generation: GenerationId): RegionCounterKey {
+  return `played_region:${generation}`;
+}
+
+const FIXED = new Set<string>(FIXED_COUNTER_KEYS);
+const REGION_KEY = /^(champion_region|played_region):([1-9])$/;
+
+/**
+ * Whether a key read back from storage is one this build knows.
+ *
+ * Unknown keys are dropped rather than kept: a blob written by a *newer* build
+ * would otherwise round-trip keys this one cannot reason about, and a typo
+ * would live forever.
+ */
+export function isCounterKey(key: string): key is CounterKey {
+  return FIXED.has(key) || REGION_KEY.test(key);
+}

--- a/src/app/services/stats-service/stats.service.spec.ts
+++ b/src/app/services/stats-service/stats.service.spec.ts
@@ -1,0 +1,182 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StatsService, PlayerStats } from './stats.service';
+import { championRegionKey, playedRegionKey } from './counter-keys';
+
+describe('StatsService', () => {
+  let service: StatsService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(StatsService);
+  });
+
+  afterAll(() => localStorage.clear());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('counters', () => {
+    it('reads an untouched counter as zero rather than undefined', () => {
+      expect(service.get('runs_completed')).toBe(0);
+    });
+
+    it('accumulates', () => {
+      service.increment('spins_total');
+      service.increment('spins_total', 4);
+
+      expect(service.get('spins_total')).toBe(5);
+    });
+
+    it('ignores a non-positive increment', () => {
+      service.increment('spins_total', 3);
+      service.increment('spins_total', -2);
+      service.increment('spins_total', 0);
+
+      expect(service.get('spins_total'))
+        .withContext('counters are grow-only; a negative increment is a bug, not history')
+        .toBe(3);
+    });
+
+    it('ignores a non-finite increment', () => {
+      service.increment('spins_total', Number.NaN);
+      expect(service.get('spins_total')).toBe(0);
+    });
+
+    it('stores nothing for a counter that never moved', () => {
+      service.increment('spins_total');
+
+      const stored = JSON.parse(localStorage.getItem('pokemon-roulette-stats')!) as PlayerStats;
+
+      expect(Object.keys(stored))
+        .withContext('only non-zero counters are stored, as on the server')
+        .toEqual(['spins_total']);
+    });
+
+    it('emits on change', () => {
+      const seen: PlayerStats[] = [];
+      service.stats$.subscribe(stats => seen.push(stats));
+
+      service.increment('eggs_hatched');
+
+      expect(seen.length).toBe(2);
+      expect(seen[1]['eggs_hatched']).toBe(1);
+    });
+  });
+
+  describe('recording a completed run', () => {
+    it('counts the run and the region', () => {
+      service.recordChampion(4, 6);
+
+      expect(service.get('runs_completed')).toBe(1);
+      expect(service.get(championRegionKey(4))).toBe(1);
+    });
+
+    it('counts a full team of six', () => {
+      service.recordChampion(1, 6);
+
+      expect(service.get('champion_with_six')).toBe(1);
+      expect(service.get('champion_with_three_or_fewer')).toBe(0);
+    });
+
+    it('counts three or fewer', () => {
+      service.recordChampion(1, 3);
+
+      expect(service.get('champion_with_three_or_fewer')).toBe(1);
+      expect(service.get('champion_with_six')).toBe(0);
+    });
+
+    it('counts neither for a team in between', () => {
+      service.recordChampion(1, 4);
+
+      expect(service.get('champion_with_six')).toBe(0);
+      expect(service.get('champion_with_three_or_fewer')).toBe(0);
+    });
+
+    it('records the region a run started in separately from winning it', () => {
+      service.recordRunStarted(7);
+
+      expect(service.get(playedRegionKey(7))).toBe(1);
+      expect(service.get(championRegionKey(7)))
+        .withContext('starting a run in a region is not beating it')
+        .toBe(0);
+    });
+  });
+
+  describe('reading stored stats', () => {
+    const read = (stored: unknown): PlayerStats => {
+      localStorage.setItem('pokemon-roulette-stats', JSON.stringify(stored));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      return TestBed.inject(StatsService).currentStats;
+    };
+
+    it('survives a reload', () => {
+      service.increment('runs_completed', 12);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+
+      expect(TestBed.inject(StatsService).get('runs_completed')).toBe(12);
+    });
+
+    it('drops a key this build does not know', () => {
+      const stats = read({ runs_completed: 3, counter_from_the_future: 9 }) as Record<string, unknown>;
+
+      expect(stats['runs_completed']).toBe(3);
+      expect(stats['counter_from_the_future'])
+        .withContext('an unknown key may be a typo, or from a build whose meaning this one cannot honour')
+        .toBeUndefined();
+    });
+
+    it('drops a value of the wrong type', () => {
+      const stats = read({ runs_completed: 'lots', spins_total: 4 }) as Record<string, unknown>;
+
+      expect(stats['runs_completed']).toBeUndefined();
+      expect(stats['spins_total']).toBe(4);
+    });
+
+    it('drops a negative value', () => {
+      const stats = read({ runs_completed: -5 }) as Record<string, unknown>;
+      expect(stats['runs_completed']).toBeUndefined();
+    });
+
+    it('accepts a valid region counter', () => {
+      const stats = read({ 'champion_region:9': 2 }) as Record<string, unknown>;
+      expect(stats['champion_region:9']).toBe(2);
+    });
+
+    it('rejects a region outside the nine that exist', () => {
+      const stats = read({ 'champion_region:12': 1 }) as Record<string, unknown>;
+      expect(stats['champion_region:12']).toBeUndefined();
+    });
+
+    it('falls back to empty on a malformed blob', () => {
+      localStorage.setItem('pokemon-roulette-stats', 'not json at all');
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+
+      expect(TestBed.inject(StatsService).currentStats).toEqual({});
+    });
+  });
+
+  describe('the synced flag', () => {
+    it('is false once anything changes locally', () => {
+      service.markSynced();
+      expect(service.isSynced).toBeTrue();
+
+      service.increment('spins_total');
+
+      expect(service.isSynced)
+        .withContext('local state is ahead of the server again, and signing out would discard it')
+        .toBeFalse();
+    });
+
+    it('is false before anything has ever synced', () => {
+      expect(service.isSynced).toBeFalse();
+    });
+  });
+});

--- a/src/app/services/stats-service/stats.service.ts
+++ b/src/app/services/stats-service/stats.service.ts
@@ -1,0 +1,201 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import {
+  CounterKey,
+  GenerationId,
+  championRegionKey,
+  isCounterKey,
+  playedRegionKey,
+} from './counter-keys';
+
+/**
+ * Lifetime counters, keyed by their wire names.
+ *
+ * Absent means zero. Only non-zero counters are stored, which keeps the blob
+ * small and matches the backend, where a row exists only once a counter has
+ * moved.
+ */
+export type PlayerStats = Readonly<Partial<Record<CounterKey, number>>>;
+
+/**
+ * Everything the game counts over a player's lifetime.
+ *
+ * Deliberately *not* the Pokédex: how many distinct Pokémon, shinies or megas
+ * you have is already answerable from `PokedexService`, and duplicating it here
+ * would create two versions of the same truth that could disagree. Achievements
+ * read both.
+ *
+ * Nothing here is ever reset, and nothing decreases — the same grow-only
+ * property the backend relies on to merge two devices without losing progress.
+ */
+@Injectable({ providedIn: 'root' })
+export class StatsService {
+  private readonly STORAGE_KEY = 'pokemon-roulette-stats';
+  private readonly SYNCED_KEY = 'pokemon-roulette-stats-synced';
+
+  private statsSubject$: BehaviorSubject<PlayerStats>;
+
+  constructor() {
+    this.statsSubject$ = new BehaviorSubject(this.getInitialStats());
+  }
+
+  get stats$(): Observable<PlayerStats> {
+    return this.statsSubject$.asObservable();
+  }
+
+  get currentStats(): PlayerStats {
+    return this.statsSubject$.getValue();
+  }
+
+  /** Reads a counter. Absent means zero; callers never need to check. */
+  get(key: CounterKey): number {
+    return this.currentStats[key] ?? 0;
+  }
+
+  /**
+   * Adds to a counter.
+   *
+   * Increments of zero or less are ignored rather than applied: counters are
+   * grow-only, and a caller passing a negative number is a bug that should not
+   * be able to rewrite history.
+   */
+  increment(key: CounterKey, by: number = 1): void {
+    if (!Number.isFinite(by) || by <= 0) {
+      return;
+    }
+
+    this.update({ ...this.currentStats, [key]: this.get(key) + Math.floor(by) });
+  }
+
+  /** Records that a run began in a region. */
+  recordRunStarted(generation: GenerationId): void {
+    this.increment(playedRegionKey(generation));
+  }
+
+  /**
+   * Records a completed run, in one call, because the facts arrive together.
+   *
+   * `teamSizeAtChampionBattle` is the size when the champion wheel spun, not at
+   * the end — depositing to the PC beforehand is allowed, and that moment is
+   * what the "Pokémon Stadium" and "Full House" achievements are about.
+   */
+  recordChampion(generation: GenerationId, teamSizeAtChampionBattle: number): void {
+    const next: Record<string, number> = { ...this.currentStats };
+
+    const bump = (key: CounterKey) => {
+      next[key] = (next[key] ?? 0) + 1;
+    };
+
+    bump('runs_completed');
+    bump(championRegionKey(generation));
+
+    if (teamSizeAtChampionBattle >= 6) {
+      bump('champion_with_six');
+    }
+    if (teamSizeAtChampionBattle > 0 && teamSizeAtChampionBattle <= 3) {
+      bump('champion_with_three_or_fewer');
+    }
+
+    this.update(next as PlayerStats);
+  }
+
+  /**
+   * Whether every local change has reached the server.
+   *
+   * Signing out clears local data, so this is what lets the UI warn before
+   * discarding progress that was never saved to an account. It is also how the
+   * sync client knows there is anything to push.
+   */
+  get isSynced(): boolean {
+    return localStorage.getItem(this.SYNCED_KEY) === 'true';
+  }
+
+  /** Called by the sync client after a successful push. */
+  markSynced(): void {
+    this.setSynced(true);
+  }
+
+  private update(stats: PlayerStats): void {
+    const pruned = this.withoutZeros(stats);
+    this.saveToStorage(pruned);
+    // Any change means local state is ahead of the server again.
+    this.setSynced(false);
+    this.statsSubject$.next(pruned);
+  }
+
+  private withoutZeros(stats: PlayerStats): PlayerStats {
+    const kept: Record<string, number> = {};
+    for (const [key, value] of Object.entries(stats)) {
+      if (typeof value === 'number' && value > 0) {
+        kept[key] = value;
+      }
+    }
+    return kept as PlayerStats;
+  }
+
+  /**
+   * Reads stored stats, keeping only what this build can reason about.
+   *
+   * There is deliberately no backfill from the existing Pokédex. Distinct
+   * caught, shinies and megas are *derived* from it rather than counted here,
+   * so there is nothing to seed. Run counts genuinely cannot be recovered for
+   * players who were here before this shipped, and start at zero.
+   */
+  private getInitialStats(): PlayerStats {
+    const stored = this.getFromStorage();
+    if (!stored) {
+      return {};
+    }
+
+    const stats: Record<string, number> = {};
+    for (const [key, value] of Object.entries(stored)) {
+      // A key this build does not know is dropped, not carried: it may be a
+      // typo, or from a newer build whose meaning this one cannot honour.
+      if (!isCounterKey(key)) {
+        continue;
+      }
+      if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        continue;
+      }
+      stats[key] = Math.floor(value);
+    }
+
+    return stats as PlayerStats;
+  }
+
+  private setSynced(synced: boolean): void {
+    try {
+      localStorage.setItem(this.SYNCED_KEY, String(synced));
+    } catch (error) {
+      console.error('Failed to record sync state:', error);
+    }
+  }
+
+  private saveToStorage(stats: PlayerStats): void {
+    // Wrapped because a private-browsing context throws on write, and losing a
+    // counter must never take the game down mid-run.
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(stats));
+    } catch (error) {
+      console.error('Failed to save stats to localStorage:', error);
+    }
+  }
+
+  private getFromStorage(): Record<string, unknown> | null {
+    const storageItem = localStorage.getItem(this.STORAGE_KEY);
+    if (!storageItem) {
+      return null;
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(storageItem);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch (error) {
+      console.error('Invalid stats localStorage item:', storageItem, 'falling back to empty stats');
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #48. The prerequisite for every achievement — **nothing in the game counted anything before this.** `TrainerService` makes no `localStorage` calls at all, so badges, team and items died with the tab, and there were no counters of any kind.

**401/401 tests** (the 380 baseline plus 21), build green, initial bundle unchanged at 1.50 MB.

## The counter names are the wire format

They're exactly the keys the backend accepts, so a stats blob syncs with **no translation layer to drift**. Adding one means adding it to the backend allowlist too, and the backend must ship first — or the key is *skipped* until it does. Skipped, not lost: the client sends absolute state, so it lands on the next sync.

## Grow-only, enforced at both ends

A non-positive or non-finite increment is **ignored rather than applied**. That's the same property the backend merge relies on, and having both ends refuse to go backwards means a bug on either side can't rewrite a player's history.

Only non-zero counters are stored, matching the server where a row exists only once a counter moves. Keys this build doesn't recognise are dropped on load — they're either a typo or from a newer build whose meaning this one can't honour.

## `recordChampion` takes the team size at the *spin*

Not at the end of the run. Depositing to the PC beforehand is allowed, and that moment is what "Pokémon Stadium" and "Full House" are actually about. Getting this wrong would make one achievement free and the other unearnable.

## A correction to the issue I wrote

**There is no backfill, and there shouldn't be.** I'd said distinct caught, shinies and megas would be seeded from the existing Pokédex. They're *derived* from it rather than counted here — seeding them would create two versions of the same truth that could disagree, and the achievement engine reads `PokedexService` directly.

Run counts genuinely can't be recovered for existing players and start at zero. Unavoidable, and now stated rather than implied.

## The `synced` flag

Any local change clears it; the sync client will set it. It's what lets the UI warn before a sign-out discards progress that never reached an account — which matters now that **logout wipes `localStorage`**.