### PR TITLE
Achievement catalog and evaluation engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,18 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 - `ModalQueueService` — serializes `NgbModal` opens so chained result modals don't stomp each other. Prefer it over `NgbModal` directly for anything the game flow triggers.
 - `SoundFxService` — `playSoundFx('click')`; sounds are named by a `SoundFxName` union, not by per-caller handles. Honors the mute setting.
 - `SettingsService` / `ThemeService` — persisted to `localStorage` (`pokemon-roulette-settings`, `pokemon-roulette-theme`).
+- `SyncStateService` — one flag: has local progress reached the account? Owned separately because
+  three collections sync, and a flag inside one of them would report "saved" while another had
+  unsaved changes. **Signing out clears local data**, so this is what lets the UI warn first.
+- `BadgeDexService` — every badge ever earned, across runs (`pokemon-roulette-badge-dex`).
+  `TrainerService.trainerBadges` is the *current run* and dies with it. Badge ids are the
+  translation key minus the `badges.` prefix — all 77 are unique, and the prefix is an i18n
+  namespace the backend's id pattern rejects.
+- `AchievementService` + `achievement-catalog.ts` — the frozen 50. Every achievement is *derivable*,
+  but unlocks are **stored anyway, for notification state**: without a record of what has been
+  announced, signing in on a new device fires fifty toasts. A stored unlock is **never removed**,
+  even if a retuned threshold means it no longer derives. Adding one is adding a row — and adding it
+  to the backend allowlist first.
 - `StatsService` — lifetime counters, persisted to `pokemon-roulette-stats`. **The counter names are
   the wire format**: they are exactly the keys the backend accepts, so a blob syncs without
   translation, and adding one means adding it to the backend's allowlist too (backend first, or the

--- a/src/app/services/achievement-service/achievement-catalog.spec.ts
+++ b/src/app/services/achievement-service/achievement-catalog.spec.ts
@@ -1,0 +1,85 @@
+import { ACHIEVEMENTS, AchievementContext, achievementDescriptionKey, achievementNameKey } from './achievement-catalog';
+
+describe('the achievement catalog', () => {
+  const emptyContext: AchievementContext = {
+    stats: {},
+    caught: new Set(),
+    shinyIds: new Set(),
+    megaCount: 0,
+    badges: new Set(),
+    highestCatchCount: 0,
+  };
+
+  it('holds the frozen fifty', () => {
+    expect(ACHIEVEMENTS.length)
+      .withContext('the catalog is frozen; adding one needs the backend allowlist updated first')
+      .toBe(50);
+  });
+
+  it('has no duplicate ids', () => {
+    const ids = ACHIEVEMENTS.map(a => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('uses ids the backend will accept', () => {
+    // The server validates against ^[a-z0-9_]{1,64}$ and rejects anything else,
+    // so a stray dot or capital here would be silently dropped on sync.
+    for (const { id } of ACHIEVEMENTS) {
+      expect(id).withContext(`${id} is not a valid achievement id`).toMatch(/^[a-z0-9_]{1,64}$/);
+    }
+  });
+
+  it('derives translation keys from the id', () => {
+    expect(achievementNameKey('oh_shiny')).toBe('achievements.oh_shiny.name');
+    expect(achievementDescriptionKey('oh_shiny')).toBe('achievements.oh_shiny.description');
+  });
+
+  it('reports no progress and no target of zero on an empty account', () => {
+    for (const achievement of ACHIEVEMENTS) {
+      const progress = achievement.progress(emptyContext);
+
+      expect(progress.current)
+        .withContext(`${achievement.id} starts part-way done`)
+        .toBe(0);
+      expect(progress.target)
+        .withContext(`${achievement.id} has a target of zero, so it would unlock immediately`)
+        .toBeGreaterThan(0);
+    }
+  });
+
+  it('counts a caught Pokémon towards the collection tiers', () => {
+    const context: AchievementContext = { ...emptyContext, caught: new Set([25]) };
+    const first = ACHIEVEMENTS.find(a => a.id === 'i_choose_you')!;
+
+    expect(first.progress(context)).toEqual({ current: 1, target: 1 });
+  });
+
+  it('treats a shiny legendary as earned only for a legendary', () => {
+    const achievement = ACHIEVEMENTS.find(a => a.id === 'never_tell_me_the_odds')!;
+
+    // Pikachu is not legendary.
+    expect(achievement.progress({ ...emptyContext, shinyIds: new Set([25]) }).current).toBe(0);
+    // Mewtwo is.
+    expect(achievement.progress({ ...emptyContext, shinyIds: new Set([150]) }).current).toBe(1);
+  });
+
+  it('measures regional dex progress against the region you are closest to finishing', () => {
+    const achievement = ACHIEVEMENTS.find(a => a.id === 'gotta_catch_em_all_regional')!;
+
+    // Two of Johto's hundred beats one of Kanto's hundred and fifty-one.
+    const progress = achievement.progress({ ...emptyContext, caught: new Set([1, 152, 153]) });
+
+    expect(progress.target).withContext('Johto has 100 species').toBe(100);
+    expect(progress.current).toBe(2);
+  });
+
+  it('hides the achievements a player may never be able to earn', () => {
+    // Region-locked encounters: a player who only ever visits Johto cannot
+    // reach these, and three permanently locked rows read as broken.
+    for (const id of ['five_hundred_steps', 'friend_code', 'the_great_crater']) {
+      expect(ACHIEVEMENTS.find(a => a.id === id)!.hidden)
+        .withContext(`${id} is region-locked and should be hidden`)
+        .toBeTrue();
+    }
+  });
+});

--- a/src/app/services/achievement-service/achievement-catalog.ts
+++ b/src/app/services/achievement-service/achievement-catalog.ts
@@ -1,0 +1,213 @@
+import { PlayerStats } from '../stats-service/stats.service';
+import { CounterKey, GENERATION_IDS, GenerationId, championRegionKey, playedRegionKey } from '../stats-service/counter-keys';
+import { pokedexByGeneration } from '../../pokedex/pokedex-by-generation';
+import { starterByGeneration } from '../../main-game/roulette-container/roulettes/starter-roulette/starter-by-generation';
+import { fossilByGeneration } from '../../main-game/roulette-container/roulettes/fossil-roulette/fossil-by-generation';
+import { legendaryByGeneration } from '../../main-game/roulette-container/roulettes/legendary-roulette/legendaries-by-generation';
+import { ALL_BADGE_IDS, GENERATIONS_WITH_BADGES, badgeRoundsForGeneration } from '../badge-dex-service/badge-dex.service';
+
+/**
+ * Everything an achievement may read.
+ *
+ * The derived counts are precomputed once per evaluation rather than by each
+ * row: fifty achievements each walking a thousand-entry Pokédex would be fifty
+ * thousand iterations for one catch.
+ */
+export interface AchievementContext {
+  readonly stats: PlayerStats;
+  /** Pokémon ids with a Pokédex entry — obtained at least once. */
+  readonly caught: ReadonlySet<number>;
+  readonly shinyIds: ReadonlySet<number>;
+  readonly megaCount: number;
+  readonly badges: ReadonlySet<string>;
+  /** The most times any single Pokémon has been caught. */
+  readonly highestCatchCount: number;
+}
+
+/** How far along an achievement is. Unlocked is `current >= target`. */
+export interface Progress {
+  readonly current: number;
+  readonly target: number;
+}
+
+export type AchievementGroup =
+  | 'collection'
+  | 'shiny'
+  | 'champion'
+  | 'rival'
+  | 'forms'
+  | 'encounters'
+  | 'badges'
+  | 'grind';
+
+export interface Achievement {
+  readonly id: string;
+  readonly group: AchievementGroup;
+  /**
+   * Hidden until earned, so there is something to discover rather than a
+   * checklist to grind. Also used for the three region-locked encounters, which
+   * a player who never visits that region can never earn — a permanently
+   * locked visible row reads as broken.
+   */
+  readonly hidden?: boolean;
+  readonly progress: (context: AchievementContext) => Progress;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+const counter = (key: CounterKey, target: number) =>
+  (context: AchievementContext): Progress => ({
+    current: context.stats[key] ?? 0,
+    target,
+  });
+
+const distinctCaught = (target: number) =>
+  (context: AchievementContext): Progress => ({ current: context.caught.size, target });
+
+const shinies = (target: number) =>
+  (context: AchievementContext): Progress => ({ current: context.shinyIds.size, target });
+
+/** How many of a set of Pokémon have been obtained. */
+const owned = (ids: readonly number[], context: AchievementContext): number =>
+  ids.reduce((total, id) => (context.caught.has(id) ? total + 1 : total), 0);
+
+const allOf = (ids: readonly number[]) =>
+  (context: AchievementContext): Progress => ({ current: owned(ids, context), target: ids.length });
+
+/** The best progress across regions — the region you are closest to finishing. */
+const bestRegion = (idsByGeneration: Record<number, number[]>) =>
+  (context: AchievementContext): Progress => {
+    let best: Progress = { current: 0, target: 1 };
+    let bestRatio = -1;
+
+    for (const generation of GENERATION_IDS) {
+      const ids = idsByGeneration[generation];
+      if (!ids?.length) {
+        continue;
+      }
+      const current = owned(ids, context);
+      const ratio = current / ids.length;
+      if (ratio > bestRatio) {
+        bestRatio = ratio;
+        best = { current, target: ids.length };
+      }
+    }
+
+    return best;
+  };
+
+const LEGENDARY_IDS: readonly number[] = GENERATION_IDS.flatMap(g => legendaryByGeneration[g] ?? []);
+
+const everySpecies: readonly number[] = GENERATION_IDS.flatMap(g => pokedexByGeneration[g] ?? []);
+
+/** Regions where every gym has been beaten — one badge from each of its rounds. */
+const regionsFullyBadged = (context: AchievementContext): number =>
+  GENERATIONS_WITH_BADGES.reduce((total, generation) => {
+    const rounds = badgeRoundsForGeneration(generation);
+    const complete = rounds.length > 0 && rounds.every(round => round.some(id => context.badges.has(id)));
+    return complete ? total + 1 : total;
+  }, 0);
+
+/** Regions with at least one counter above zero — championed, or played. */
+const regionsWhere = (key: (generation: GenerationId) => CounterKey) =>
+  (context: AchievementContext): number =>
+    GENERATION_IDS.reduce((total, g) => ((context.stats[key(g)] ?? 0) > 0 ? total + 1 : total), 0);
+
+const championedRegions = regionsWhere(championRegionKey);
+const playedRegions = regionsWhere(playedRegionKey);
+
+// --- the catalog -----------------------------------------------------------
+
+/**
+ * The frozen catalog: https://github.com/zeroxm/pokemon-roulette/issues/50
+ *
+ * Ids are frozen — the backend validates against exactly this list, and
+ * renaming one after players hold it means a data migration on live accounts.
+ * Name and description translation keys are derived from the id
+ * (`achievements.<id>.name`), so they cannot drift out of step with it.
+ *
+ * Adding one is adding a row. It must also be added to the backend allowlist,
+ * and the backend must deploy first.
+ */
+export const ACHIEVEMENTS: readonly Achievement[] = [
+  // Collection — derived from the Pokédex.
+  { id: 'i_choose_you', group: 'collection', progress: distinctCaught(1) },
+  { id: 'pokedex_lv_1', group: 'collection', progress: distinctCaught(10) },
+  { id: 'pokedex_lv_2', group: 'collection', progress: distinctCaught(50) },
+  { id: 'pokedex_lv_3', group: 'collection', progress: distinctCaught(100) },
+  { id: 'pokedex_lv_4', group: 'collection', progress: distinctCaught(250) },
+  { id: 'pokedex_lv_5', group: 'collection', progress: distinctCaught(500) },
+  { id: 'gotta_catch_em_all_national', group: 'collection', progress: allOf(everySpecies) },
+  { id: 'gotta_catch_em_all_regional', group: 'collection', progress: bestRegion(pokedexByGeneration) },
+  { id: 'i_choose_you_and_you', group: 'collection', progress: allOf(GENERATION_IDS.flatMap(g => starterByGeneration[g] ?? [])) },
+  { id: 'paleontologist', group: 'collection', progress: allOf(GENERATION_IDS.flatMap(g => fossilByGeneration[g] ?? [])) },
+  { id: 'myth_buster', group: 'collection', progress: bestRegion(legendaryByGeneration) },
+
+  // Shiny — also derived from the Pokédex.
+  { id: 'oh_shiny', group: 'shiny', progress: shinies(1) },
+  { id: 'shiny_hunter_1', group: 'shiny', progress: shinies(5) },
+  { id: 'shiny_hunter_2', group: 'shiny', progress: shinies(10) },
+  { id: 'shiny_hunter_3', group: 'shiny', progress: shinies(25) },
+  {
+    id: 'never_tell_me_the_odds',
+    group: 'shiny',
+    progress: context => ({
+      current: LEGENDARY_IDS.some(id => context.shinyIds.has(id)) ? 1 : 0,
+      target: 1,
+    }),
+  },
+
+  // Champion.
+  { id: 'champion', group: 'champion', progress: counter('runs_completed', 1) },
+  { id: 'regional_champion', group: 'champion', progress: c => ({ current: championedRegions(c), target: 3 }) },
+  { id: 'world_champion', group: 'champion', progress: c => ({ current: championedRegions(c), target: 9 }) },
+  { id: 'full_house', group: 'champion', progress: counter('champion_with_six', 1) },
+  { id: 'pokemon_stadium', group: 'champion', hidden: true, progress: counter('champion_with_three_or_fewer', 1) },
+
+  // Rival.
+  { id: 'smell_ya_later', group: 'rival', progress: counter('rival_battles_won', 1) },
+  { id: 'notch_above', group: 'rival', progress: counter('rival_battles_won', 5) },
+  { id: 'fruitful_battle', group: 'rival', progress: counter('rival_battles_won', 10) },
+
+  // Forms.
+  { id: 'evolved_beyond_1', group: 'forms', progress: c => ({ current: c.megaCount, target: 1 }) },
+  { id: 'evolved_beyond_2', group: 'forms', progress: c => ({ current: c.megaCount, target: 10 }) },
+  { id: 'its_a_disguise', group: 'forms', progress: counter('mimikyu_disguises_busted', 1) },
+  { id: 'bond_phenomenon', group: 'forms', progress: counter('ash_greninja_transformations', 1) },
+  { id: 'shapeshifter', group: 'forms', progress: counter('sticky_forms_triggered', 1) },
+
+  // Encounters.
+  { id: 'super_rod', group: 'encounters', progress: counter('fishing_catches', 10) },
+  { id: 'super_nerd', group: 'encounters', progress: counter('fossil_catches', 10) },
+  { id: 'prepare_for_trouble', group: 'encounters', progress: counter('team_rocket_defeats', 1) },
+  { id: 'make_it_double', group: 'encounters', progress: counter('team_rocket_rescues', 1) },
+  { id: 'mystery_gift', group: 'encounters', progress: counter('eggs_hatched', 1) },
+  { id: 'used_the_pokeflute', group: 'encounters', progress: counter('snorlax_resolved', 1) },
+  // Region-locked: Kanto, Kalos and Paldea only. Hidden, because a player who
+  // never visits those regions would otherwise stare at three rows they cannot
+  // earn and reasonably conclude something is broken.
+  { id: 'five_hundred_steps', group: 'encounters', hidden: true, progress: counter('safari_zone_visits', 1) },
+  { id: 'friend_code', group: 'encounters', hidden: true, progress: counter('friend_safari_visits', 1) },
+  { id: 'the_great_crater', group: 'encounters', hidden: true, progress: counter('area_zero_visits', 1) },
+  { id: 'a_fair_trade', group: 'encounters', progress: counter('trades_completed', 1) },
+
+  // Badge dex.
+  { id: 'champ_in_the_making', group: 'badges', progress: c => ({ current: c.badges.size, target: 1 }) },
+  { id: 'off_to_victory_road', group: 'badges', progress: c => ({ current: regionsFullyBadged(c), target: 1 }) },
+  { id: 'badger_badger_badger', group: 'badges', progress: c => ({ current: regionsFullyBadged(c), target: 3 }) },
+  { id: 'the_very_best', group: 'badges', progress: c => ({ current: c.badges.size, target: ALL_BADGE_IDS.size }) },
+
+  // Grind.
+  { id: 'youngster', group: 'grind', progress: counter('runs_completed', 10) },
+  { id: 'bug_catcher', group: 'grind', progress: counter('runs_completed', 25) },
+  { id: 'ace_trainer', group: 'grind', progress: counter('runs_completed', 50) },
+  { id: 'veteran', group: 'grind', progress: counter('runs_completed', 100) },
+  { id: 'wheel_of_fortune', group: 'grind', progress: counter('spins_total', 1000) },
+  { id: 'whos_that_pokemon', group: 'grind', progress: c => ({ current: c.highestCatchCount, target: 50 }) },
+  { id: 'world_tour', group: 'grind', progress: c => ({ current: playedRegions(c), target: 9 }) },
+];
+
+export type AchievementId = typeof ACHIEVEMENTS[number]['id'];
+
+export const achievementNameKey = (id: string): string => `achievements.${id}.name`;
+export const achievementDescriptionKey = (id: string): string => `achievements.${id}.description`;

--- a/src/app/services/achievement-service/achievement.service.spec.ts
+++ b/src/app/services/achievement-service/achievement.service.spec.ts
@@ -1,0 +1,127 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AchievementService } from './achievement.service';
+import { Achievement } from './achievement-catalog';
+import { StatsService } from '../stats-service/stats.service';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
+
+describe('AchievementService', () => {
+  const withPokedex = (caught: Record<string, unknown>) =>
+    localStorage.setItem('pokemon-roulette-pokedex', JSON.stringify({ caught }));
+
+  const inject = (): AchievementService => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    return TestBed.inject(AchievementService);
+  };
+
+  beforeEach(() => localStorage.clear());
+  afterAll(() => localStorage.clear());
+
+  it('should be created', () => {
+    expect(inject()).toBeTruthy();
+  });
+
+  it('unlocks what the collection already implies', () => {
+    withPokedex({ 25: { won: true, sprite: null } });
+
+    expect(inject().isUnlocked('i_choose_you')).toBeTrue();
+  });
+
+  // A longtime player opening the game after this ships has earned a dozen
+  // things, but earned them months ago. Announcing them would be a wall of
+  // toasts for history.
+  it('records the first evaluation silently', () => {
+    withPokedex({ 25: { won: true, sprite: null } });
+
+    const service = inject();
+    const announced: Achievement[][] = [];
+    service.newlyUnlocked$.subscribe(batch => announced.push(batch));
+
+    expect(service.isUnlocked('i_choose_you')).withContext('it should still be recorded').toBeTrue();
+    expect(announced).withContext('but not announced').toEqual([]);
+  });
+
+  it('announces what is earned afterwards', () => {
+    const service = inject();
+
+    const announced: Achievement[] = [];
+    service.newlyUnlocked$.subscribe(batch => announced.push(...batch));
+
+    TestBed.inject(StatsService).increment('runs_completed');
+
+    expect(announced.map(a => a.id)).toContain('champion');
+  });
+
+  it('announces each achievement once', () => {
+    const service = inject();
+    const stats = TestBed.inject(StatsService);
+
+    const announced: Achievement[] = [];
+    service.newlyUnlocked$.subscribe(batch => announced.push(...batch));
+
+    stats.increment('runs_completed');
+    stats.increment('runs_completed');
+
+    expect(announced.filter(a => a.id === 'champion').length)
+      .withContext('a second run must not re-announce the first-champion achievement')
+      .toBe(1);
+  });
+
+  it('survives a reload', () => {
+    withPokedex({ 25: { won: true, sprite: null } });
+    inject();
+
+    expect(inject().isUnlocked('i_choose_you')).toBeTrue();
+  });
+
+  // Retuning a threshold can leave a stored unlock that no longer derives.
+  // Taking it away would mean a tuning change removing something earned.
+  it('keeps an unlock that no longer derives', () => {
+    localStorage.setItem(
+      'pokemon-roulette-achievements',
+      JSON.stringify({ pokedex_lv_5: '2026-01-01T00:00:00.000Z' }),
+    );
+
+    expect(inject().isUnlocked('pokedex_lv_5'))
+      .withContext('the Pokédex is empty, yet the player earned this before')
+      .toBeTrue();
+  });
+
+  it('drops a stored id this build does not know', () => {
+    localStorage.setItem(
+      'pokemon-roulette-achievements',
+      JSON.stringify({ achievement_from_the_future: '2026-01-01T00:00:00.000Z' }),
+    );
+
+    expect(inject().isUnlocked('achievement_from_the_future')).toBeFalse();
+  });
+
+  it('falls back to none unlocked on a malformed blob', () => {
+    localStorage.setItem('pokemon-roulette-achievements', 'not json');
+
+    expect(Object.keys(inject().unlocked)).toEqual([]);
+  });
+
+  it('reports progress for every achievement', () => {
+    withPokedex({ 25: { won: true, sprite: null }, 6: { won: true, sprite: null } });
+
+    let progress: ReadonlyMap<string, { current: number; target: number }> = new Map();
+    inject().progress$.subscribe(p => (progress = p));
+
+    expect(progress.size).toBe(50);
+    expect(progress.get('pokedex_lv_1')).toEqual({ current: 2, target: 10 });
+  });
+
+  it('marks local state dirty when something unlocks', () => {
+    const service = inject();
+    TestBed.inject(SyncStateService).markSynced();
+
+    TestBed.inject(StatsService).increment('runs_completed');
+
+    expect(service.isUnlocked('champion')).toBeTrue();
+    expect(TestBed.inject(SyncStateService).isSynced)
+      .withContext('an unlock is synced state; it has to be pushed')
+      .toBeFalse();
+  });
+});

--- a/src/app/services/achievement-service/achievement.service.ts
+++ b/src/app/services/achievement-service/achievement.service.ts
@@ -1,0 +1,183 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject, combineLatest } from 'rxjs';
+import { PokedexData, PokedexService } from '../pokedex-service/pokedex.service';
+import { StatsService } from '../stats-service/stats.service';
+import { BadgeDexService } from '../badge-dex-service/badge-dex.service';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
+import { ACHIEVEMENTS, Achievement, AchievementContext, Progress } from './achievement-catalog';
+
+/** When each achievement was earned, keyed by id. ISO 8601, UTC. */
+export type AchievementUnlocks = Readonly<Record<string, string>>;
+
+/**
+ * Decides what the player has earned, and announces what is new.
+ *
+ * Every achievement is *derivable* from the collections, so the unlocked set
+ * could be recomputed from scratch at any time. It is stored anyway, for one
+ * reason: **notification state.** Without a record of what has already been
+ * announced, a player signing in on a new device would be met with fifty
+ * toasts at once.
+ *
+ * That storage is also why a stored unlock is never taken away. Retuning a
+ * threshold can leave one that no longer derives — and having something you
+ * earned removed by a tuning change is the worse outcome.
+ */
+@Injectable({ providedIn: 'root' })
+export class AchievementService {
+  private readonly STORAGE_KEY = 'pokemon-roulette-achievements';
+
+  private unlockedSubject$: BehaviorSubject<AchievementUnlocks>;
+  private newlyUnlockedSubject$ = new Subject<Achievement[]>();
+  private progressSubject$ = new BehaviorSubject<ReadonlyMap<string, Progress>>(new Map());
+
+  constructor(
+    private pokedexService: PokedexService,
+    private statsService: StatsService,
+    private badgeDexService: BadgeDexService,
+    private syncState: SyncStateService,
+  ) {
+    const stored = this.getStoredUnlocks();
+    this.unlockedSubject$ = new BehaviorSubject(stored);
+
+    // A player who has never had achievements evaluated has earned everything
+    // their collection already implies, but earned it *before* now. Announcing
+    // it would fire a dozen toasts at a longtime player for things they did
+    // months ago, so the first pass records silently.
+    let announce = Object.keys(stored).length > 0 || localStorage.getItem(this.STORAGE_KEY) !== null;
+
+    combineLatest([
+      this.pokedexService.pokedex$,
+      this.statsService.stats$,
+      this.badgeDexService.earned$,
+    ]).subscribe(([pokedex, , badges]) => {
+      this.evaluate(pokedex, badges, announce);
+      announce = true;
+    });
+  }
+
+  get unlocked$(): Observable<AchievementUnlocks> {
+    return this.unlockedSubject$.asObservable();
+  }
+
+  get unlocked(): AchievementUnlocks {
+    return this.unlockedSubject$.getValue();
+  }
+
+  /** Achievements that just became earned. What the milestone toast listens to. */
+  get newlyUnlocked$(): Observable<Achievement[]> {
+    return this.newlyUnlockedSubject$.asObservable();
+  }
+
+  /** Current progress for every achievement, for the achievements screen. */
+  get progress$(): Observable<ReadonlyMap<string, Progress>> {
+    return this.progressSubject$.asObservable();
+  }
+
+  isUnlocked(id: string): boolean {
+    return id in this.unlocked;
+  }
+
+  private evaluate(pokedex: PokedexData, badges: ReadonlySet<string>, announce: boolean): void {
+    const context = this.buildContext(pokedex, badges);
+
+    const progress = new Map<string, Progress>();
+    const earned: Achievement[] = [];
+
+    for (const achievement of ACHIEVEMENTS) {
+      const result = achievement.progress(context);
+      progress.set(achievement.id, result);
+
+      if (result.current >= result.target && !this.isUnlocked(achievement.id)) {
+        earned.push(achievement);
+      }
+    }
+
+    this.progressSubject$.next(progress);
+
+    if (earned.length === 0) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const unlocks: Record<string, string> = { ...this.unlocked };
+    for (const achievement of earned) {
+      unlocks[achievement.id] = now;
+    }
+
+    this.save(unlocks);
+    this.syncState.markDirty();
+    this.unlockedSubject$.next(unlocks);
+
+    if (announce) {
+      this.newlyUnlockedSubject$.next(earned);
+    }
+  }
+
+  private buildContext(pokedex: PokedexData, badges: ReadonlySet<string>): AchievementContext {
+    const caught = new Set<number>();
+    const shinyIds = new Set<number>();
+    let megaCount = 0;
+    let highestCatchCount = 0;
+
+    for (const [key, entry] of Object.entries(pokedex.caught)) {
+      const id = Number(key);
+      if (!Number.isFinite(id)) {
+        continue;
+      }
+
+      caught.add(id);
+      if (entry.shiny) {
+        shinyIds.add(id);
+      }
+      if (entry.mega) {
+        megaCount++;
+      }
+      highestCatchCount = Math.max(highestCatchCount, entry.count ?? 0);
+    }
+
+    return {
+      stats: this.statsService.currentStats,
+      caught,
+      shinyIds,
+      megaCount,
+      badges,
+      highestCatchCount,
+    };
+  }
+
+  private save(unlocks: AchievementUnlocks): void {
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(unlocks));
+    } catch (error) {
+      console.error('Failed to save achievements to localStorage:', error);
+    }
+  }
+
+  private getStoredUnlocks(): AchievementUnlocks {
+    const storageItem = localStorage.getItem(this.STORAGE_KEY);
+    if (!storageItem) {
+      return {};
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(storageItem);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return {};
+      }
+
+      const known = new Set(ACHIEVEMENTS.map(a => a.id));
+      const unlocks: Record<string, string> = {};
+      for (const [id, at] of Object.entries(parsed as Record<string, unknown>)) {
+        // An id this build does not know cannot be displayed, and would count
+        // towards nothing. Dropping it also keeps a typo from living forever.
+        if (known.has(id) && typeof at === 'string') {
+          unlocks[id] = at;
+        }
+      }
+      return unlocks;
+    } catch (error) {
+      console.error('Invalid achievements localStorage item:', storageItem, 'falling back to none unlocked');
+      return {};
+    }
+  }
+}

--- a/src/app/services/badge-dex-service/badge-dex.service.spec.ts
+++ b/src/app/services/badge-dex-service/badge-dex.service.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  ALL_BADGE_IDS,
+  BadgeDexService,
+  badgeId,
+  badgeRoundsForGeneration,
+} from './badge-dex.service';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
+
+describe('BadgeDexService', () => {
+  let service: BadgeDexService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BadgeDexService);
+  });
+
+  afterAll(() => localStorage.clear());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('badge ids', () => {
+    // Badges have no id of their own, only a translation key. The namespace is
+    // stripped because the backend's id pattern rejects the dot.
+    it('strips the i18n namespace', () => {
+      expect(badgeId({ name: 'badges.bug_paldea', sprite: '' })).toBe('bug_paldea');
+    });
+
+    it('produces ids the backend will accept', () => {
+      for (const id of ALL_BADGE_IDS) {
+        expect(id).withContext(`${id} is not a valid badge id`).toMatch(/^[a-z0-9_]{1,64}$/);
+      }
+    });
+
+    it('is unique across every generation', () => {
+      // Type-named badges repeat across regions; the _kalos/_galar/_paldea
+      // suffixes are what keep them distinct.
+      expect(ALL_BADGE_IDS.size).toBe(77);
+    });
+
+    it('groups a round that offers a choice', () => {
+      const rounds = badgeRoundsForGeneration(7);
+      const withChoice = rounds.filter(round => round.length > 1);
+
+      expect(withChoice.length)
+        .withContext("Alola's Z-crystal rounds offer alternatives")
+        .toBeGreaterThan(0);
+    });
+
+    it('gives every generation eight rounds', () => {
+      for (let generation = 1; generation <= 9; generation++) {
+        expect(badgeRoundsForGeneration(generation).length)
+          .withContext(`generation ${generation}`)
+          .toBe(8);
+      }
+    });
+  });
+
+  describe('recording', () => {
+    it('remembers a badge permanently', () => {
+      service.record({ name: 'badges.boulder', sprite: '' });
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+
+      expect(TestBed.inject(BadgeDexService).earned.has('boulder')).toBeTrue();
+    });
+
+    it('is idempotent', () => {
+      service.record({ name: 'badges.boulder', sprite: '' });
+      service.record({ name: 'badges.boulder', sprite: '' });
+
+      expect(service.earned.size).toBe(1);
+    });
+
+    it('marks local state dirty', () => {
+      const syncState = TestBed.inject(SyncStateService);
+      syncState.markSynced();
+
+      service.record({ name: 'badges.cascade', sprite: '' });
+
+      expect(syncState.isSynced).toBeFalse();
+    });
+
+    it('drops a stored id this build does not know', () => {
+      localStorage.setItem('pokemon-roulette-badge-dex', JSON.stringify(['boulder', 'badge_from_the_future']));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+
+      const earned = TestBed.inject(BadgeDexService).earned;
+
+      expect(earned.has('boulder')).toBeTrue();
+      expect(earned.has('badge_from_the_future'))
+        .withContext('a badge that no longer exists would count towards "every badge" forever')
+        .toBeFalse();
+    });
+  });
+});

--- a/src/app/services/badge-dex-service/badge-dex.service.ts
+++ b/src/app/services/badge-dex-service/badge-dex.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Badge } from '../../interfaces/badge';
+import { badgesByGeneration } from '../badges-service/badges-data';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
+
+/**
+ * Every badge the player has ever earned, across every run.
+ *
+ * `TrainerService.trainerBadges` is the badges of the *current* run and dies
+ * with it. This is the lifetime record — the trophy case — and it is one of the
+ * three collections that sync.
+ *
+ * Grow-only: badges are only ever added.
+ */
+@Injectable({ providedIn: 'root' })
+export class BadgeDexService {
+  private readonly STORAGE_KEY = 'pokemon-roulette-badge-dex';
+
+  private earnedSubject$: BehaviorSubject<ReadonlySet<string>>;
+
+  constructor(private syncState: SyncStateService) {
+    this.earnedSubject$ = new BehaviorSubject(this.getInitialBadges());
+  }
+
+  get earned$(): Observable<ReadonlySet<string>> {
+    return this.earnedSubject$.asObservable();
+  }
+
+  get earned(): ReadonlySet<string> {
+    return this.earnedSubject$.getValue();
+  }
+
+  has(badge: Badge): boolean {
+    return this.earned.has(badgeId(badge));
+  }
+
+  /** Records a badge permanently. A badge already held is a no-op. */
+  record(badge: Badge): void {
+    const id = badgeId(badge);
+    if (!id || this.earned.has(id)) {
+      return;
+    }
+
+    const next = new Set(this.earned);
+    next.add(id);
+    this.save(next);
+    this.syncState.markDirty();
+    this.earnedSubject$.next(next);
+  }
+
+  private save(badges: ReadonlySet<string>): void {
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify([...badges].sort()));
+    } catch (error) {
+      console.error('Failed to save the badge dex to localStorage:', error);
+    }
+  }
+
+  private getInitialBadges(): ReadonlySet<string> {
+    const storageItem = localStorage.getItem(this.STORAGE_KEY);
+    if (!storageItem) {
+      return new Set();
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(storageItem);
+      if (!Array.isArray(parsed)) {
+        return new Set();
+      }
+      // Only ids this build knows: a badge that no longer exists cannot be
+      // displayed, and would count towards "every badge in the game" forever.
+      return new Set(parsed.filter((id): id is string => typeof id === 'string' && ALL_BADGE_IDS.has(id)));
+    } catch (error) {
+      console.error('Invalid badge dex localStorage item:', storageItem, 'falling back to none earned');
+      return new Set();
+    }
+  }
+}
+
+/**
+ * The stored id for a badge.
+ *
+ * Badges have no id of their own — only a translation key like
+ * `badges.bug_paldea`, which is unique across all 77 of them. The `badges.`
+ * prefix is stripped because it is an i18n namespace, not part of the
+ * identity, and because the backend's id pattern rejects the dot.
+ */
+export function badgeId(badge: Badge): string {
+  return badge.name.startsWith('badges.') ? badge.name.slice('badges.'.length) : badge.name;
+}
+
+/** The badges defined for one generation, flattened across alternatives. */
+export function badgeIdsForGeneration(generation: number): string[] {
+  return (badgesByGeneration[generation] ?? []).flatMap(round =>
+    Array.isArray(round) ? round.map(badgeId) : [badgeId(round)],
+  );
+}
+
+/**
+ * The badges for each round of a generation, kept grouped.
+ *
+ * Four rounds offer a choice — Alola's Z-crystals, for instance — so beating
+ * all eight gyms of a region means holding one badge from each round, not
+ * every badge the region defines.
+ */
+export function badgeRoundsForGeneration(generation: number): string[][] {
+  return (badgesByGeneration[generation] ?? []).map(round =>
+    Array.isArray(round) ? round.map(badgeId) : [badgeId(round)],
+  );
+}
+
+export const GENERATIONS_WITH_BADGES: readonly number[] = Object.keys(badgesByGeneration)
+  .map(Number)
+  .sort((a, b) => a - b);
+
+/** Every badge id in the game, alternatives included. */
+export const ALL_BADGE_IDS: ReadonlySet<string> = new Set(
+  GENERATIONS_WITH_BADGES.flatMap(badgeIdsForGeneration),
+);

--- a/src/app/services/pokedex-service/pokedex.service.ts
+++ b/src/app/services/pokedex-service/pokedex.service.ts
@@ -8,6 +8,14 @@ export interface PokedexEntry {
   sprite: string | null;
   shiny?: boolean;
   mega?: boolean;
+  /**
+   * Times this Pokémon has been caught. Absent on entries written before catch
+   * counting existed; #53 introduces the writes and seeds those to 1.
+   *
+   * A row exists because the Pokémon was obtained at least once, so 0 is never
+   * a meaningful value — the backend has a CHECK enforcing that.
+   */
+  count?: number;
 }
 
 export interface PokedexData {

--- a/src/app/services/stats-service/stats.service.spec.ts
+++ b/src/app/services/stats-service/stats.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { StatsService, PlayerStats } from './stats.service';
 import { championRegionKey, playedRegionKey } from './counter-keys';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
 
 describe('StatsService', () => {
   let service: StatsService;
@@ -163,20 +164,17 @@ describe('StatsService', () => {
     });
   });
 
-  describe('the synced flag', () => {
-    it('is false once anything changes locally', () => {
-      service.markSynced();
-      expect(service.isSynced).toBeTrue();
+  describe('sync state', () => {
+    it('marks local state dirty once a counter changes', () => {
+      const syncState = TestBed.inject(SyncStateService);
+      syncState.markSynced();
+      expect(syncState.isSynced).toBeTrue();
 
       service.increment('spins_total');
 
-      expect(service.isSynced)
+      expect(syncState.isSynced)
         .withContext('local state is ahead of the server again, and signing out would discard it')
         .toBeFalse();
-    });
-
-    it('is false before anything has ever synced', () => {
-      expect(service.isSynced).toBeFalse();
     });
   });
 });

--- a/src/app/services/stats-service/stats.service.ts
+++ b/src/app/services/stats-service/stats.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
 import {
   CounterKey,
   GenerationId,
@@ -31,11 +32,10 @@ export type PlayerStats = Readonly<Partial<Record<CounterKey, number>>>;
 @Injectable({ providedIn: 'root' })
 export class StatsService {
   private readonly STORAGE_KEY = 'pokemon-roulette-stats';
-  private readonly SYNCED_KEY = 'pokemon-roulette-stats-synced';
 
   private statsSubject$: BehaviorSubject<PlayerStats>;
 
-  constructor() {
+  constructor(private syncState: SyncStateService) {
     this.statsSubject$ = new BehaviorSubject(this.getInitialStats());
   }
 
@@ -99,27 +99,11 @@ export class StatsService {
     this.update(next as PlayerStats);
   }
 
-  /**
-   * Whether every local change has reached the server.
-   *
-   * Signing out clears local data, so this is what lets the UI warn before
-   * discarding progress that was never saved to an account. It is also how the
-   * sync client knows there is anything to push.
-   */
-  get isSynced(): boolean {
-    return localStorage.getItem(this.SYNCED_KEY) === 'true';
-  }
-
-  /** Called by the sync client after a successful push. */
-  markSynced(): void {
-    this.setSynced(true);
-  }
-
   private update(stats: PlayerStats): void {
     const pruned = this.withoutZeros(stats);
     this.saveToStorage(pruned);
-    // Any change means local state is ahead of the server again.
-    this.setSynced(false);
+    // Local state is ahead of the server again.
+    this.syncState.markDirty();
     this.statsSubject$.next(pruned);
   }
 
@@ -161,14 +145,6 @@ export class StatsService {
     }
 
     return stats as PlayerStats;
-  }
-
-  private setSynced(synced: boolean): void {
-    try {
-      localStorage.setItem(this.SYNCED_KEY, String(synced));
-    } catch (error) {
-      console.error('Failed to record sync state:', error);
-    }
   }
 
   private saveToStorage(stats: PlayerStats): void {

--- a/src/app/services/sync-state-service/sync-state.service.ts
+++ b/src/app/services/sync-state-service/sync-state.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * Whether local progress has reached the player's account.
+ *
+ * Owned by its own service because three collections are synced — counters,
+ * badges and achievement unlocks — and a flag living inside one of them would
+ * quietly report "saved" while another had unsaved changes.
+ *
+ * It matters because **signing out clears local data**. This is what lets the
+ * UI warn before discarding progress that was never saved to an account.
+ */
+@Injectable({ providedIn: 'root' })
+export class SyncStateService {
+  private readonly STORAGE_KEY = 'pokemon-roulette-synced';
+
+  private syncedSubject$: BehaviorSubject<boolean>;
+
+  constructor() {
+    this.syncedSubject$ = new BehaviorSubject(localStorage.getItem(this.STORAGE_KEY) === 'true');
+  }
+
+  get synced$(): Observable<boolean> {
+    return this.syncedSubject$.asObservable();
+  }
+
+  get isSynced(): boolean {
+    return this.syncedSubject$.getValue();
+  }
+
+  /** Called by anything that changes synced state. */
+  markDirty(): void {
+    this.set(false);
+  }
+
+  /** Called by the sync client after a successful push. */
+  markSynced(): void {
+    this.set(true);
+  }
+
+  private set(synced: boolean): void {
+    if (this.isSynced === synced) {
+      return;
+    }
+
+    try {
+      localStorage.setItem(this.STORAGE_KEY, String(synced));
+    } catch (error) {
+      console.error('Failed to record sync state:', error);
+    }
+
+    this.syncedSubject$.next(synced);
+  }
+}


### PR DESCRIPTION
Closes #49. The frozen fifty as a declarative table, plus the engine that decides what's earned and announces what's new.

**430/430 tests**, build green, initial bundle unchanged at 1.50 MB.

Each row is an id, a group, and a `progress(context) => {current, target}` function — so the UI gets progress bars from the *same* definition that decides unlocking, not a second parallel one. Name and description keys are derived from the id, so they can't drift.

## A real mismatch this found

**Badges have no id.** They have a translation key like `badges.bug_paldea` — and **the backend's id pattern rejects the dot**, so every badge sync would have failed. Ids are now the key minus the `badges.` prefix: an i18n namespace isn't part of an identity. All 77 are unique and match the pattern, with a test asserting it.

## Two services came along, both necessary

**`BadgeDexService`** is the data half of #54 — the catalog can't be complete without it. `TrainerService.trainerBadges` is the *current run* and dies with it, so there was no lifetime badge record at all.

**`SyncStateService`** exists because the `synced` flag I put in `StatsService` last PR **would have lied.** Three collections sync — counters, badges, unlocks — and a flag inside one reports "saved" while another has unsaved changes. That matters because signing out clears local data.

## The decision worth reviewing

**The first evaluation records silently.** A longtime player opening the game after this ships has earned a dozen achievements — but earned them months ago. Announcing them would be a wall of toasts for history. Subsequent evaluations announce normally.

That's the same problem storing unlocks exists to solve, one layer up: the stored set stops a *new device* from firing fifty toasts; this stops the *first run after upgrade* from doing it.

**Stored unlocks are never removed**, even when a retuned threshold means one no longer derives. Having something taken away by a tuning change is worse than carrying an unlock that no longer computes — there's a test pinning that.

## Two judgement calls, flagged not buried

- **"All 8 badges in one region"** = one badge from each of the eight *rounds*. Four rounds offer a choice (Alola's Z-crystals), so this is about beating eight gyms, not collecting every variant.
- **"Every badge in the game"** = all **77** including alternatives, because that one *is* about collecting.

Tell me if you'd read either differently.

## Notes

- No species→generation table was needed — `pokedex-by-generation.ts` already exists with the national dex ranges.
- `PokedexEntry` gains an optional `count`, which #53 writes. Until then `whos_that_pokemon` sits at zero.
- The three region-locked encounters are **hidden**, per the catalog review: a player who only ever plays Johto would otherwise stare at three rows they cannot earn.