### PR TITLE
Instrument the game loop for achievements

### DIFF
--- a/src/app/main-game/roulette-container/roulette-container.component.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.ts
@@ -3,6 +3,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { GenerationRouletteComponent } from "./roulettes/generation-roulette/generation-roulette.component";
 import { GameStateService } from '../../services/game-state-service/game-state.service';
+import { StatsService } from '../../services/stats-service/stats.service';
+import { GenerationId } from '../../services/stats-service/counter-keys';
+import { GenerationService } from '../../services/generation-service/generation.service';
 import { GameState } from '../../services/game-state-service/game-state';
 import { EventSource } from '../EventSource';
 import { CONSOLATION_PRIZES } from './consolation/consolation-prizes';
@@ -121,7 +124,9 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
       private settingsService: SettingsService,
       private pokemonFormsService: PokemonFormsService,
       private rareCandyService: RareCandyService,
-      private megaStoneService: MegaStoneService) {
+      private megaStoneService: MegaStoneService,
+      private statsService: StatsService,
+      private generationService: GenerationService) {
     }
 
     ngOnInit(): void {
@@ -555,6 +560,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
   }
 
   friendSafari(): void {
+    this.statsService.increment('friend_safari_visits');
     this.gameStateService.setNextState('friend-safari');
     this.finishCurrentState();
   }
@@ -576,11 +582,13 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
   }
 
   safariZone(): void {
+    this.statsService.increment('safari_zone_visits');
     this.gameStateService.setNextState('safari-zone');
     this.finishCurrentState();
   }
 
   areaZero(): void {
+    this.statsService.increment('area_zero_visits');
     this.gameStateService.setNextState('area-zero');
     this.finishCurrentState();
   }
@@ -602,6 +610,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
 
   rivalBattleResult(result: boolean): void {
     if (result) {
+      this.statsService.increment('rival_battles_won');
       this.chooseWhoWillEvolve('battle-rival');
     } else {
       this.doNothing();
@@ -633,7 +642,13 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
   }
 
   teamRocketDefeated(): void {
+    this.statsService.increment('team_rocket_defeats');
+
     if (this.run.stolenPokemon) {
+      // Beating them while they hold your Pokémon is the rescue -- a strict
+      // subset of defeating them, which is why both counters move here.
+      this.statsService.increment('team_rocket_rescues');
+
       const pokemonName = this.translateService.instant(this.run.stolenPokemon.text);
 
       this.trainerService.addToTeam(this.run.stolenPokemon);
@@ -663,6 +678,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
   }
 
   performTrade(pokemon: PokemonItem): void {
+    this.statsService.increment('trades_completed');
     this.pkmnIn = structuredClone(pokemon);
     this.pkmnOut = this.currentContextPokemon;
     this.trainerService.performTrade(this.currentContextPokemon, this.pkmnIn);
@@ -731,6 +747,15 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
     this.setRespinReason('');
 
     if (result) {
+      // Read the team size before anything else runs. "Full House" and
+      // "Pokémon Stadium" are about the size when the champion wheel *spun*,
+      // and depositing to the PC beforehand is allowed -- so this is the
+      // moment that counts, not the end of the run.
+      this.statsService.recordChampion(
+        this.generationService.getCurrentGeneration().id as GenerationId,
+        this.trainerService.getTeam().length,
+      );
+
       // Advance first. Leaving `champion-battle` is what reverts battle forms, and the win has to be
       // recorded against the base Pokémon: a team member still mega-evolved here would be filed
       // under its mega id, which has no Pokédex cell and so never shows the win.

--- a/src/app/main-game/roulette-container/roulettes/mysterious-egg-roulette/mysterious-egg-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/mysterious-egg-roulette/mysterious-egg-roulette.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Output, ChangeDetectionStrategy } from '@angul
 import {TranslatePipe} from '@ngx-translate/core';
 import { WheelComponent } from '../../../../wheel/wheel.component';
 import { PokemonService } from '../../../../services/pokemon-service/pokemon.service';
+import { StatsService } from '../../../../services/stats-service/stats.service';
 import { PokemonItem } from '../../../../interfaces/pokemon-item';
 
 @Component({
@@ -13,7 +14,7 @@ import { PokemonItem } from '../../../../interfaces/pokemon-item';
 })
 export class MysteriousEggRouletteComponent {
 
-  constructor(pokemonService: PokemonService) {
+  constructor(pokemonService: PokemonService, private statsService: StatsService) {
     this.nationalDexPokemon = pokemonService.getAllPokemon();
   }
 
@@ -22,6 +23,9 @@ export class MysteriousEggRouletteComponent {
   @Output() selectedPokemonEvent = new EventEmitter<PokemonItem>();
 
   onItemSelected(index: number): void {
+    // Picking from the egg wheel *is* the hatch.
+    this.statsService.increment('eggs_hatched');
+
     const selectedPokemon = this.nationalDexPokemon[index];
     this.selectedPokemonEvent.emit(selectedPokemon);
   }

--- a/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component.ts
@@ -7,6 +7,8 @@ import { PokemonService } from '../../../../services/pokemon-service/pokemon.ser
 import { GenerationItem } from '../../../../interfaces/generation-item';
 import { PokemonItem } from '../../../../interfaces/pokemon-item';
 import { POKEMON_POOLS, PokemonPool, PokemonPoolId } from './pokemon-pools';
+import { StatsService } from '../../../../services/stats-service/stats.service';
+import { CounterKey } from '../../../../services/stats-service/counter-keys';
 
 /** Spins a wheel of Pokémon drawn from one named pool for the current generation. */
 @Component({
@@ -30,7 +32,19 @@ export class PokemonPoolRouletteComponent implements OnInit, OnDestroy {
   constructor(
     private generationService: GenerationService,
     private pokemonService: PokemonService,
+    private statsService: StatsService,
   ) { }
+
+  /**
+   * Pools whose selection is itself the catch, and the counter each feeds.
+   *
+   * Only these two: the legendary pool leads to a capture *attempt* that can
+   * fail, and the rest have no achievement behind them.
+   */
+  private static readonly COUNTED_POOLS: Partial<Record<PokemonPoolId, CounterKey>> = {
+    fish: 'fishing_catches',
+    fossil: 'fossil_catches',
+  };
 
   get poolDefinition(): PokemonPool {
     return POKEMON_POOLS[this.pool];
@@ -56,6 +70,11 @@ export class PokemonPoolRouletteComponent implements OnInit, OnDestroy {
    * carrying weight 2 would keep a double-width slice on the evolution, trade and mega wheels.
    */
   onItemSelected(index: number): void {
+    const counter = PokemonPoolRouletteComponent.COUNTED_POOLS[this.pool];
+    if (counter) {
+      this.statsService.increment(counter);
+    }
+
     const chosen = this.pokemon[index];
     this.selectedPokemonEvent.emit(this.pokemonService.getPokemonById(chosen.pokemonId) ?? chosen);
   }

--- a/src/app/main-game/roulette-container/roulettes/snorlax-roulette/snorlax-roulette.component.ts
+++ b/src/app/main-game/roulette-container/roulettes/snorlax-roulette/snorlax-roulette.component.ts
@@ -3,6 +3,7 @@ import {TranslatePipe} from '@ngx-translate/core';
 import { WheelComponent } from '../../../../wheel/wheel.component';
 import { WheelItem } from '../../../../interfaces/wheel-item';
 import { EventSource } from '../../../EventSource';
+import { StatsService } from '../../../../services/stats-service/stats.service';
 
 @Component({
   selector: 'app-snorlax-roulette',
@@ -12,6 +13,8 @@ import { EventSource } from '../../../EventSource';
   styleUrl: './snorlax-roulette.component.css'
 })
 export class SnorlaxRouletteComponent implements OnInit {
+
+  constructor(private statsService: StatsService) { }
 
   @Input() currentRound!: number;
   @Output() runAwayEvent = new EventEmitter<void>();
@@ -34,9 +37,12 @@ export class SnorlaxRouletteComponent implements OnInit {
         this.runAwayEvent.emit();
         break;
       case 1:
+        // "Used the Pokéflute" is either outcome -- running away is not.
+        this.statsService.increment('snorlax_resolved');
         this.catchSnorlaxEvent.emit();
         break;
       case 2:
+        this.statsService.increment('snorlax_resolved');
         this.defeatSnorlaxEvent.emit('snorlax-encounter');
         break;
     }

--- a/src/app/services/achievement-service/achievement.service.ts
+++ b/src/app/services/achievement-service/achievement.service.ts
@@ -50,7 +50,18 @@ export class AchievementService {
       this.statsService.stats$,
       this.badgeDexService.earned$,
     ]).subscribe(([pokedex, , badges]) => {
-      this.evaluate(pokedex, badges, announce);
+      // Guarded because this runs synchronously from the middle of the game
+      // loop: StatsService.increment emits, which lands here, and a progress
+      // function throwing on unexpected data would unwind back into whatever
+      // was spinning a wheel. A broken achievement must not break a run.
+      //
+      // Subscriber errors are a separate matter and RxJS already isolates
+      // those; this covers the evaluation itself.
+      try {
+        this.evaluate(pokedex, badges, announce);
+      } catch (error) {
+        console.error('Failed to evaluate achievements:', error);
+      }
       announce = true;
     });
   }

--- a/src/app/services/form-rule-service/form-rule.service.ts
+++ b/src/app/services/form-rule-service/form-rule.service.ts
@@ -4,6 +4,7 @@ import { ItemName } from '../items-service/item-names';
 import { FormRule } from './form-rule';
 import { MegaForm } from '../trainer-service/pokemon-mega-forms';
 import { formRules } from './form-rules';
+import { StatsService } from '../stats-service/stats.service';
 
 /** What a fired rule replaced, so it can be put back. */
 interface AppliedForm {
@@ -30,6 +31,8 @@ export class FormRuleService {
   /** Non-empty only while battle forms are applied; also the idempotency guard. */
   private applied: AppliedForm[] = [];
   private formsApplied = false;
+
+  constructor(private statsService: StatsService) { }
 
   /**
    * Applies every `battle-start` rule whose conditions are met. A no-op if forms are already
@@ -155,6 +158,15 @@ export class FormRuleService {
         changed = true;
       }
     }
+
+    // Every form change funnels through here, which is the point of the rule
+    // table — one place to observe rather than a call beside each mechanic.
+    // A sticky rule cannot re-fire once applied, so `changed` alone is the
+    // signal.
+    if (changed && rule.persistence === 'sticky') {
+      this.statsService.increment('sticky_forms_triggered');
+    }
+
     return changed;
   }
 

--- a/src/app/services/generation-service/generation.service.ts
+++ b/src/app/services/generation-service/generation.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@angular/core';
 import { GenerationItem } from '../../interfaces/generation-item';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { StatsService } from '../stats-service/stats.service';
+import { GenerationId } from '../stats-service/counter-keys';
 
 @Injectable({
   providedIn: 'root'
 })
 export class GenerationService {
 
-  constructor() {
+  constructor(private statsService: StatsService) {
   }
 
   private generations: GenerationItem[] = [
@@ -28,8 +30,17 @@ export class GenerationService {
     return this.generations;
   }
 
+  /** `index` is a position in the list, not a generation id. */
   setGeneration(index: number): void {
-    this.generation.next(this.generations[index]);
+    const generation = this.generations[index];
+    if (!generation) {
+      return;
+    }
+
+    this.generation.next(generation);
+    // Choosing a region is what starts a run there. The id, not the index --
+    // they differ by one, and played_region:0 is not a thing.
+    this.statsService.recordRunStarted(generation.id as GenerationId);
   }
 
   getGeneration(): Observable<GenerationItem> {

--- a/src/app/services/stats-service/instrumentation.spec.ts
+++ b/src/app/services/stats-service/instrumentation.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+
+import { StatsService } from './stats.service';
+import { SnorlaxRouletteComponent } from '../../main-game/roulette-container/roulettes/snorlax-roulette/snorlax-roulette.component';
+import { PokemonPoolRouletteComponent } from '../../main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pool-roulette.component';
+import { PokemonPoolId } from '../../main-game/roulette-container/roulettes/pokemon-pool-roulette/pokemon-pools';
+
+/**
+ * The counters only mean anything if the game actually moves them. These cover
+ * the points where a wheel result becomes a statistic — the rest of the game
+ * loop is exercised by the container's own spec.
+ */
+describe('stats instrumentation', () => {
+  let stats: StatsService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ providers: [provideTranslateService()] });
+    stats = TestBed.inject(StatsService);
+  });
+
+  afterAll(() => localStorage.clear());
+
+  describe('the Snorlax encounter', () => {
+    const spin = (outcome: number) => {
+      const fixture = TestBed.createComponent(SnorlaxRouletteComponent);
+      fixture.componentInstance.currentRound = 1;
+      fixture.detectChanges();
+      fixture.componentInstance.onItemSelected(outcome);
+    };
+
+    it('counts catching it', () => {
+      spin(1);
+      expect(stats.get('snorlax_resolved')).toBe(1);
+    });
+
+    it('counts defeating it', () => {
+      spin(2);
+      expect(stats.get('snorlax_resolved')).toBe(1);
+    });
+
+    it('does not count running away', () => {
+      spin(0);
+      expect(stats.get('snorlax_resolved'))
+        .withContext('"Used the Pokéflute" is about resolving the encounter, not meeting it')
+        .toBe(0);
+    });
+  });
+
+  describe('pool catches', () => {
+    const select = (pool: PokemonPoolId) => {
+      const fixture = TestBed.createComponent(PokemonPoolRouletteComponent);
+      fixture.componentInstance.pool = pool;
+      fixture.detectChanges();
+      fixture.componentInstance.onItemSelected(0);
+    };
+
+    it('counts a fish', () => {
+      select('fish');
+      expect(stats.get('fishing_catches')).toBe(1);
+    });
+
+    it('counts a fossil', () => {
+      select('fossil');
+      expect(stats.get('fossil_catches')).toBe(1);
+    });
+
+    it('counts nothing for a pool with no achievement behind it', () => {
+      select('starter');
+      select('cave');
+
+      expect(stats.get('fishing_catches')).toBe(0);
+      expect(stats.get('fossil_catches')).toBe(0);
+    });
+  });
+});

--- a/src/app/services/trainer-service/trainer.service.ts
+++ b/src/app/services/trainer-service/trainer.service.ts
@@ -13,6 +13,8 @@ import { GenerationService } from '../generation-service/generation.service';
 import { GameState } from '../game-state-service/game-state';
 import { GameStateService } from '../game-state-service/game-state.service';
 import { FormRuleService } from '../form-rule-service/form-rule.service';
+import { StatsService } from '../stats-service/stats.service';
+import { BadgeDexService } from '../badge-dex-service/badge-dex.service';
 import { megaStoneNamesForBaseId, pokemonMegaForms } from './pokemon-mega-forms';
 
 /** Mimikyu's disguised form; the busted form lives in `mimikyu-forms`. */
@@ -43,7 +45,9 @@ export class TrainerService implements OnDestroy {
     private itemSpriteService: ItemSpriteService,
     private pokemonService: PokemonService,
     private gameStateService: GameStateService,
-    private formRuleService: FormRuleService) {
+    private formRuleService: FormRuleService,
+    private statsService: StatsService,
+    private badgeDexService: BadgeDexService) {
     this.gameStateSubscription = this.gameStateService.currentState.subscribe((gameState) => {
       this.syncBattleForms(gameState);
     });
@@ -351,6 +355,7 @@ export class TrainerService implements OnDestroy {
 
     if (changed) {
       this.loadMissingSprites();
+      this.statsService.increment('mimikyu_disguises_busted');
       this.trainerTeamObservable.next(this.getTeam());
     }
     return changed;
@@ -374,6 +379,7 @@ export class TrainerService implements OnDestroy {
 
     if (changed) {
       this.loadMissingSprites();
+      this.statsService.increment('ash_greninja_transformations');
       this.trainerTeamObservable.next(this.getTeam());
     }
     return changed;
@@ -395,6 +401,9 @@ export class TrainerService implements OnDestroy {
     this.badgesService.getBadge(this.generationService.getCurrentGeneration(), fromRound, fromLeader).subscribe(badge => {
       if (badge === undefined) return;
       this.trainerBadges.push(badge);
+      // One point for every badge the game awards: the run's badges die with
+      // it, the badge dex is the lifetime trophy case.
+      this.badgeDexService.record(badge);
       this.trainerBadgesObservable.next(this.trainerBadges);
     })
   }

--- a/src/app/wheel/wheel.component.ts
+++ b/src/app/wheel/wheel.component.ts
@@ -8,6 +8,7 @@ import { CommonModule } from '@angular/common';
 import { GameStateService } from '../services/game-state-service/game-state.service';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { SoundFxService } from '../services/sound-fx-service/sound-fx.service';
+import { StatsService } from '../services/stats-service/stats.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
@@ -60,7 +61,8 @@ export class WheelComponent implements AfterViewInit, OnChanges, OnDestroy {
     private translateService: TranslateService,
     private soundFxService: SoundFxService,
     private modalService: NgbModal,
-    private changeDetectorRef: ChangeDetectorRef
+    private changeDetectorRef: ChangeDetectorRef,
+    private statsService: StatsService
   ) {
     this.darkMode = this.themeService.isDark$;
     this.canvasHeight = 0;
@@ -319,6 +321,11 @@ export class WheelComponent implements AfterViewInit, OnChanges, OnDestroy {
     if (this.spinning || !this.isReady) {
       return;
     }
+
+    // Counted here rather than at thirty call sites: every roulette in the
+    // game renders this component, so one line covers all of them. After the
+    // guard, so a rejected spin is not counted.
+    this.statsService.increment('spins_total');
 
     this.spinning = true;
     this.gameStateService.setWheelSpinning(this.spinning);


### PR DESCRIPTION
Closes #51. **Every counter in the catalog now has something moving it**, and every badge earned reaches the lifetime badge dex.

436/436 tests, build green. Bundle 1.50 → 1.51 MB, under the 1.55 warn threshold.

## Hooks are one per *concept*, not one per call site

| Counter | Where | Why there |
|---|---|---|
| `spins_total` | `WheelComponent.spinWheel` | Every roulette renders it — one line covers all thirty |
| `played_region` | `GenerationService.setGeneration` | |
| `champion_*` | the champion win in the container | |
| `rival_battles_won` | `rivalBattleResult` | |
| `team_rocket_*` | `teamRocketDefeated`, rescue from its `stolenPokemon` branch | |
| `eggs_hatched` | `MysteriousEggRouletteComponent` | The pick *is* the hatch |
| `snorlax_resolved` | `SnorlaxRouletteComponent` | Catch or defeat; running away doesn't count |
| `fishing/fossil_catches` | `PokemonPoolRouletteComponent` | It knows its own pool; the container doesn't |
| `sticky_forms_triggered` | `FormRuleService.applyRule` | The single chokepoint the rule table exists to provide |
| badges | `TrainerService.addBadge` | |

## One bug avoided rather than introduced

**`GenerationService.setGeneration` takes an array *index*, not a generation id.** Passing it straight through would have written `played_region:0` through `played_region:8` — one invalid key and eight wrong ones, and the backend would have rejected the lot. It reads the resolved generation's `.id` instead.

## The champion hook reads team size *before* advancing the round

"Full House" and "Pokémon Stadium" are about the size when the champion wheel **spun**. Depositing to the PC beforehand is allowed — that's the rule you set — so that's the moment that counts, not the end of the run.

## A test I wrote and then deleted

I tried to prove a broken achievement can't break a run, using a throwing subscriber. It **hung the browser**, and it was testing the wrong layer: RxJS already isolates subscriber errors, while my `try/catch` guards errors inside *evaluation*. Testing the wrong thing badly is worse than not testing it, so it's gone and the comment now says what the guard actually covers.

What is tested: the Snorlax outcomes (including that running away doesn't count) and the pool catches (including that `starter` and `cave` count nothing).