### PR TITLE
Per-Pokémon catch counter, and drop the stored sprite

### DIFF
--- a/src/app/main-game/roulette-container/roulette-container.component.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.ts
@@ -682,7 +682,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
     this.pkmnIn = structuredClone(pokemon);
     this.pkmnOut = this.currentContextPokemon;
     this.trainerService.performTrade(this.currentContextPokemon, this.pkmnIn);
-    this.registerInPokedex(this.pkmnIn);
+    this.registerCatch(this.pkmnIn);
     this.auxPokemonList = [];
     this.playItemFoundAudio();
     void this.showModalThenContinue(() => this.openPokemonSwitchModal(
@@ -1007,7 +1007,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
   private completePokemonCapture(pokemon: PokemonItem): void {
     this.currentContextPokemon = pokemon; // ensures setShininess can reference captured pokemon
     this.trainerService.addToTeam(pokemon);
-    this.registerInPokedex(pokemon);
+    this.registerCatch(pokemon);
 
     if (this.settingsService.currentSettings.skipShinyRolls) {
       const isShiny = Math.random() < (1 / 64);
@@ -1025,6 +1025,26 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
    */
   private registerInPokedex(pokemon: PokemonItem): void {
     this.pokedexService.markSeen(pokemon.pokemonId, pokemon.shiny);
+    const baseId = this.pokemonFormsService.getBasePokemonId(pokemon.pokemonId);
+    if (baseId !== null && baseId !== pokemon.pokemonId) {
+      this.pokedexService.markSeen(baseId, pokemon.shiny);
+    }
+  }
+
+  /**
+   * Registers a newly obtained Pokémon *and* counts it as a catch.
+   *
+   * Only two paths acquire a Pokémon: a capture and a trade. Everything else
+   * that touches the Pokédex — evolving, re-registering to mark a shiny,
+   * getting a stolen Pokémon back — goes through registerInPokedex and does not
+   * count, because none of them is a new acquisition.
+   *
+   * The base species is registered but NOT counted. An alt form registers its
+   * base so it appears in the grid; catching Mega Charizard X is one catch, not
+   * two.
+   */
+  private registerCatch(pokemon: PokemonItem): void {
+    this.pokedexService.recordCatch(pokemon.pokemonId, pokemon.shiny);
     const baseId = this.pokemonFormsService.getBasePokemonId(pokemon.pokemonId);
     if (baseId !== null && baseId !== pokemon.pokemonId) {
       this.pokedexService.markSeen(baseId, pokemon.shiny);

--- a/src/app/pokedex/pokedex-detail-modal/pokedex-detail-modal.component.spec.ts
+++ b/src/app/pokedex/pokedex-detail-modal/pokedex-detail-modal.component.spec.ts
@@ -14,8 +14,8 @@ describe('PokedexDetailModalComponent', () => {
   let mockFormsService: jasmine.SpyObj<PokemonFormsService>;
   let mockActiveModal: jasmine.SpyObj<NgbActiveModal>;
 
-  const seenEntry: PokedexEntry = { won: false, sprite: null };
-  const shinyEntry: PokedexEntry = { won: true, sprite: null, shiny: true };
+  const seenEntry: PokedexEntry = { won: false };
+  const shinyEntry: PokedexEntry = { won: true, shiny: true };
 
   beforeEach(async () => {
     mockPokemonService = jasmine.createSpyObj('PokemonService', ['getPokemonById']);

--- a/src/app/pokedex/pokedex-entry/pokedex-entry.component.css
+++ b/src/app/pokedex/pokedex-entry/pokedex-entry.component.css
@@ -86,3 +86,19 @@
   display: block;
   image-rendering: pixelated;
 }
+
+/* Times caught, shown only past one — a "×1" on every cell would be noise. */
+.catch-count-badge {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  z-index: 2;
+  padding: 0 3px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 0.6rem;
+  line-height: 1.2;
+  font-weight: 600;
+  pointer-events: none;
+}

--- a/src/app/pokedex/pokedex-entry/pokedex-entry.component.html
+++ b/src/app/pokedex/pokedex-entry/pokedex-entry.component.html
@@ -10,6 +10,10 @@
 
   <span class="number-badge">{{ formatPokemonNumber(pokemonId) }}</span>
 
+  @if (showsCatchCount) {
+    <span class="catch-count-badge">&times;{{ catchCount }}</span>
+  }
+
   <div class="pokedex-cell-inner">
 
     <!-- Front face: shown when unseen -->

--- a/src/app/pokedex/pokedex-entry/pokedex-entry.component.spec.ts
+++ b/src/app/pokedex/pokedex-entry/pokedex-entry.component.spec.ts
@@ -9,8 +9,8 @@ describe('PokedexEntryComponent', () => {
   let fixture: ComponentFixture<PokedexEntryComponent>;
   let pokemonServiceSpy: jasmine.SpyObj<PokemonService>;
 
-  const seenEntry: PokedexEntry = { won: false, sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png' };
-  const wonEntry: PokedexEntry = { won: true, sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png' };
+  const seenEntry: PokedexEntry = { won: false };
+  const wonEntry: PokedexEntry = { won: true };
 
   beforeEach(async () => {
     localStorage.clear();

--- a/src/app/pokedex/pokedex-entry/pokedex-entry.component.ts
+++ b/src/app/pokedex/pokedex-entry/pokedex-entry.component.ts
@@ -5,7 +5,7 @@ import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ThemeService } from '../../services/theme-service/theme.service';
 import { PokemonService } from '../../services/pokemon-service/pokemon.service';
-import { PokedexEntry } from '../../services/pokedex-service/pokedex.service';
+import { PokedexEntry, pokemonSpriteUrl } from '../../services/pokedex-service/pokedex.service';
 import { ImageFallbackDirective } from '../../directives/image-fallback.directive';
 
 export interface PokedexEntryClickEvent {
@@ -53,7 +53,18 @@ export class PokedexEntryComponent implements OnInit {
   }
 
   get spriteUrl(): string | null {
-    return this.entry?.sprite ?? null;
+    // Derived from the id: the URL is no longer stored, because a thousand
+    // copies of the same host is most of what a saved Pokédex used to weigh.
+    return this.entry ? pokemonSpriteUrl(this.pokemonId) : null;
+  }
+
+  /** Times caught. Shown only once it is worth showing. */
+  get catchCount(): number {
+    return this.entry?.count ?? 0;
+  }
+
+  get showsCatchCount(): boolean {
+    return this.catchCount > 1;
   }
 
   onCellClick(): void {

--- a/src/app/services/pokedex-service/pokedex.service.spec.ts
+++ b/src/app/services/pokedex-service/pokedex.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { PokedexService, PokedexData } from './pokedex.service';
+import { PokedexService, PokedexData, pokemonSpriteUrl } from './pokedex.service';
 
 describe('PokedexService', () => {
   let service: PokedexService;
@@ -50,7 +50,7 @@ describe('PokedexService', () => {
 
   // DATA-03: Constructor reads from localStorage
   it('should restore state from localStorage on construction', () => {
-    const saved: PokedexData = { caught: { '4': { won: false, sprite: 'https://example.com/4.png' } } };
+    const saved: PokedexData = { caught: { '4': { won: false } } };
     localStorage.setItem('pokemon-roulette-pokedex', JSON.stringify(saved));
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({});
@@ -79,33 +79,12 @@ describe('PokedexService', () => {
   });
 
   // DATA-05: Sprite URL stored on markSeen
-  it('should store the deterministic sprite URL when markSeen is called', () => {
-    service.markSeen(1);
-    expect(service.currentPokedex.caught['1'].sprite).toBe(
+  it('derives the deterministic sprite URL from the id', () => {
+    expect(pokemonSpriteUrl(1)).toBe(
       'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png'
     );
   });
 
-  // DATA-05: markWon on unseen also stores sprite
-  it('should store sprite URL when markWon is called for unseen Pokémon', () => {
-    service.markWon([7]);
-    expect(service.currentPokedex.caught['7'].sprite).toBe(
-      'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png'
-    );
-  });
-
-  // DATA-06: In-memory cache populated after markSeen
-  it('should populate spriteCache after markSeen', () => {
-    service.markSeen(4);
-    expect((service as any)['spriteCache'].has(4)).toBeTrue();
-  });
-
-  // DATA-06: Idempotent cache (no duplicate entries)
-  it('should not duplicate spriteCache entry when markSeen called twice', () => {
-    service.markSeen(4);
-    service.markSeen(4);
-    expect((service as any)['spriteCache'].size).toBe(1);
-  });
 
   // SHINY-01: shiny flag persistence
   it('should set shiny:true on entry when markSeen called with shiny=true — SHINY-01', () => {
@@ -152,9 +131,9 @@ describe('PokedexService', () => {
   it('should normalize shiny on load for existing related entries only and persist the migration — SHINY-03', () => {
     const saved: PokedexData = {
       caught: {
-        '25': { won: false, sprite: 'https://example.com/25.png', shiny: true },
-        '26': { won: false, sprite: 'https://example.com/26.png' },
-        '172': { won: false, sprite: 'https://example.com/172.png' },
+        '25': { won: false, shiny: true },
+        '26': { won: false },
+        '172': { won: false },
       },
     };
 
@@ -208,7 +187,6 @@ describe('PokedexService', () => {
     const entry = service.currentPokedex.caught['1'];
     expect(entry.shiny).toBeTrue();
     expect(entry.won).toBeTrue();   // must be preserved — not reset by markSeen
-    expect(entry.sprite).toBeTruthy(); // sprite must not be cleared
   });
 
   // Explicit false param: markSeen(id, false) must not revert an already-shiny entry
@@ -243,5 +221,109 @@ describe('PokedexService', () => {
       expect(emitCount).toBe(1);
       done();
     }, 0);
+  });
+});
+
+describe('PokedexService catch counting', () => {
+  let service: PokedexService;
+
+  const load = (caught: unknown): PokedexService => {
+    localStorage.setItem('pokemon-roulette-pokedex', JSON.stringify({ caught }));
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    return TestBed.inject(PokedexService);
+  };
+
+  const stored = (): Record<string, Record<string, unknown>> =>
+    JSON.parse(localStorage.getItem('pokemon-roulette-pokedex')!).caught;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PokedexService);
+  });
+
+  afterAll(() => localStorage.clear());
+
+  it('starts a newly caught Pokémon at one', () => {
+    service.recordCatch(25);
+
+    expect(service.currentPokedex.caught['25'].count)
+      .withContext('an entry exists because it was obtained, so zero is never valid')
+      .toBe(1);
+  });
+
+  it('accumulates', () => {
+    service.recordCatch(25);
+    service.recordCatch(25);
+    service.recordCatch(25);
+
+    expect(service.currentPokedex.caught['25'].count).toBe(3);
+  });
+
+  // Evolving, marking a shiny and getting a stolen Pokémon back all register
+  // without acquiring anything.
+  it('does not count a registration that is not a catch', () => {
+    service.recordCatch(25);
+    service.markSeen(25);
+
+    expect(service.currentPokedex.caught['25'].count).toBe(1);
+  });
+
+  it('does not count the relatives a shiny propagates to', () => {
+    service.recordCatch(1, true); // Bulbasaur, shiny
+
+    expect(service.currentPokedex.caught['1'].count).toBe(1);
+    expect(service.currentPokedex.caught['2'].count)
+      .withContext('Ivysaur was marked shiny by propagation, not caught')
+      .toBe(1);
+    expect(service.currentPokedex.caught['2'].shiny).toBeTrue();
+  });
+
+  it('keeps the count when a Pokémon wins the game', () => {
+    service.recordCatch(25);
+    service.recordCatch(25);
+    service.markWon([25]);
+
+    expect(service.currentPokedex.caught['25'].count).toBe(2);
+    expect(service.currentPokedex.caught['25'].won).toBeTrue();
+  });
+
+  describe('upgrading an older stored Pokédex', () => {
+    it('seeds an entry that predates counting to one', () => {
+      const upgraded = load({ 25: { won: true, sprite: 'https://example.invalid/25.png' } });
+
+      expect(upgraded.currentPokedex.caught['25'].count)
+        .withContext('a floor, not a fabrication — zero beside a caught marker reads as a bug')
+        .toBe(1);
+    });
+
+    it('drops the stored sprite', () => {
+      load({ 25: { won: true, sprite: 'https://example.invalid/25.png' } });
+
+      expect('sprite' in stored()['25'])
+        .withContext('a thousand copies of one host was most of what a saved Pokédex weighed')
+        .toBeFalse();
+    });
+
+    it('preserves what the entry already meant', () => {
+      const upgraded = load({ 6: { won: true, sprite: 'x', shiny: true, mega: true } });
+      const entry = upgraded.currentPokedex.caught['6'];
+
+      expect(entry.won).toBeTrue();
+      expect(entry.shiny).toBeTrue();
+      expect(entry.mega).toBeTrue();
+    });
+
+    it('leaves an already-upgraded blob alone', () => {
+      const upgraded = load({ 25: { won: false, count: 7 } });
+
+      expect(upgraded.currentPokedex.caught['25'].count).toBe(7);
+    });
+  });
+
+  it('derives the sprite url from the id', () => {
+    expect(pokemonSpriteUrl(25)).toContain('/25.png');
   });
 });

--- a/src/app/services/pokedex-service/pokedex.service.ts
+++ b/src/app/services/pokedex-service/pokedex.service.ts
@@ -2,20 +2,32 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { evolutionChain } from '../evolution-service/evolution-chain';
 import { pokemonForms } from '../pokemon-forms-service/pokemon-forms';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
 
 export interface PokedexEntry {
   won: boolean;
-  sprite: string | null;
   shiny?: boolean;
   mega?: boolean;
   /**
-   * Times this Pokémon has been caught. Absent on entries written before catch
-   * counting existed; #53 introduces the writes and seeds those to 1.
+   * Times this Pokémon has been obtained.
    *
-   * A row exists because the Pokémon was obtained at least once, so 0 is never
-   * a meaningful value — the backend has a CHECK enforcing that.
+   * A row exists because it was obtained at least once, so the minimum is 1 and
+   * 0 is never meaningful — the backend has a CHECK enforcing that. Entries
+   * written before counting existed are seeded to 1 on load: visibly a floor
+   * rather than a fabrication.
    */
   count?: number;
+}
+
+/**
+ * Where a Pokémon's artwork comes from.
+ *
+ * Derived from the id rather than stored. It used to be a field on every entry,
+ * which made a full Pokédex about 110 KB of the same URL repeated a thousand
+ * times — and baked today's hot-linked host into every saved account.
+ */
+export function pokemonSpriteUrl(pokemonId: number): string {
+  return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemonId}.png`;
 }
 
 export interface PokedexData {
@@ -26,12 +38,11 @@ export interface PokedexData {
 export class PokedexService {
   private readonly STORAGE_KEY = 'pokemon-roulette-pokedex';
   private readonly defaultPokedex: PokedexData = { caught: {} };
-  private readonly spriteCache = new Map<number, string>();
   private readonly reverseEvolutionChain = this.buildReverseEvolutionChain();
 
   private pokedexSubject$: BehaviorSubject<PokedexData>;
 
-  constructor() {
+  constructor(private syncState: SyncStateService) {
     this.pokedexSubject$ = new BehaviorSubject(this.getInitialPokedex());
   }
 
@@ -66,13 +77,44 @@ export class PokedexService {
     this.updatePokedex({ caught: updatedCaught });
   }
 
+  /**
+   * Registers a newly obtained Pokémon and counts it.
+   *
+   * Separate from markSeen because most registrations are *not* catches:
+   * evolving, re-registering to mark a shiny, and getting a stolen Pokémon back
+   * all pass through the Pokédex without being a new acquisition. Counting them
+   * would inflate every total.
+   */
+  recordCatch(pokemonId: number, shiny: boolean = false): void {
+    const updatedCaught: Record<string, PokedexEntry> = { ...this.currentPokedex.caught };
+    const key = String(pokemonId);
+
+    // Read the count *before* upserting: upsertSeenEntry seeds a new entry at
+    // 1, since a row only exists once a Pokémon was obtained. Adding to that
+    // would make every first catch a two.
+    const previous = updatedCaught[key]?.count ?? 0;
+
+    this.upsertSeenEntry(updatedCaught, pokemonId, shiny);
+
+    updatedCaught[key] = { ...updatedCaught[key], count: previous + 1 };
+
+    // Shiny propagation runs after the count, so related forms are registered
+    // without being counted.
+    if (shiny) {
+      for (const relatedId of this.getRelatedPokemonIds(pokemonId)) {
+        this.upsertSeenEntry(updatedCaught, relatedId, true);
+      }
+    }
+
+    this.updatePokedex({ caught: updatedCaught });
+  }
+
   markWon(pokemonIds: number[]): void {
     const current = this.currentPokedex;
     const updatedCaught = { ...current.caught };
     for (const pokemonId of pokemonIds) {
       const key = String(pokemonId);
-      const sprite = this.getSpriteUrl(pokemonId);
-      updatedCaught[key] = { ...updatedCaught[key], won: true, sprite: updatedCaught[key]?.sprite ?? sprite };
+      updatedCaught[key] = { ...updatedCaught[key], won: true };
     }
     this.updatePokedex({ caught: updatedCaught });
   }
@@ -88,27 +130,14 @@ export class PokedexService {
     }
 
     const updatedCaught = { ...current.caught };
-    updatedCaught[key] = {
-      won: existing?.won ?? false,
-      sprite: existing?.sprite ?? this.getSpriteUrl(pokemonId),
-      ...(existing?.shiny ? { shiny: true } : {}),
-      mega: true,
-    };
+    updatedCaught[key] = { ...existing, won: existing?.won ?? false, mega: true };
 
     this.updatePokedex({ caught: updatedCaught });
   }
 
-  private getSpriteUrl(pokemonId: number): string {
-    if (this.spriteCache.has(pokemonId)) {
-      return this.spriteCache.get(pokemonId)!;
-    }
-    const url = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemonId}.png`;
-    this.spriteCache.set(pokemonId, url);
-    return url;
-  }
-
   private updatePokedex(data: PokedexData): void {
     this.savePokedexToStorage(data);
+    this.syncState.markDirty();
     this.pokedexSubject$.next(data);
   }
 
@@ -118,12 +147,47 @@ export class PokedexService {
       return this.defaultPokedex;
     }
 
-    const { data, changed } = this.normalizeShinyOnLoad(fromStorage);
-    if (changed) {
+    const upgraded = this.upgradeStoredEntries(fromStorage);
+    const { data, changed } = this.normalizeShinyOnLoad(upgraded.data);
+
+    if (changed || upgraded.changed) {
       this.savePokedexToStorage(data);
     }
 
     return data;
+  }
+
+  /**
+   * Brings an older stored blob up to the current shape.
+   *
+   * Two one-time changes, both idempotent: the per-entry `sprite` is dropped
+   * because it is derived from the id, and entries predating catch counting are
+   * seeded to 1.
+   *
+   * Seeding to 1 rather than 0 is deliberate. An entry exists because the
+   * Pokémon was obtained, so 1 is a floor rather than a fabrication — and a
+   * count of 0 beside a caught marker reads as a bug.
+   */
+  private upgradeStoredEntries(data: PokedexData): { data: PokedexData; changed: boolean } {
+    const upgraded: Record<string, PokedexEntry> = {};
+    let changed = false;
+
+    for (const [key, entry] of Object.entries(data.caught)) {
+      const legacy = entry as PokedexEntry & { sprite?: unknown };
+
+      if ('sprite' in legacy || legacy.count === undefined) {
+        changed = true;
+      }
+
+      upgraded[key] = {
+        won: entry.won,
+        ...(entry.shiny ? { shiny: true } : {}),
+        ...(entry.mega ? { mega: true } : {}),
+        count: typeof entry.count === 'number' && entry.count > 0 ? Math.floor(entry.count) : 1,
+      };
+    }
+
+    return { data: { caught: upgraded }, changed };
   }
 
   private upsertSeenEntry(caught: Record<string, PokedexEntry>, pokemonId: number, shiny: boolean): boolean {
@@ -132,15 +196,16 @@ export class PokedexService {
     const nextShiny = Boolean(existing?.shiny) || shiny;
     const nextEntry: PokedexEntry = {
       won: existing?.won ?? false,
-      sprite: existing?.sprite ?? this.getSpriteUrl(pokemonId),
       ...(nextShiny ? { shiny: true } : {}),
       ...(existing?.mega ? { mega: true } : {}),
+      // A row exists because the Pokémon was obtained, so the floor is 1 even
+      // for one registered without going through recordCatch.
+      count: existing?.count ?? 1,
     };
 
     const changed =
       !existing ||
       existing.won !== nextEntry.won ||
-      existing.sprite !== nextEntry.sprite ||
       Boolean(existing.shiny) !== Boolean(nextEntry.shiny);
 
     caught[key] = nextEntry;


### PR DESCRIPTION
Closes #53. 443/443 tests, build green.

## Counting a catch is mostly about deciding what isn't one

Six paths register a Pokémon in the Pokédex. **Only two acquire one:**

| Counts | Doesn't |
|---|---|
| `completePokemonCapture` | `setShininess` — re-registering the Pokémon just caught |
| `performTrade` | `teamRocketDefeated` — your own Pokémon coming back |
| | `replaceForEvolution` + the Nincada bonus — explicitly excluded |

So `PokedexService` gains `recordCatch` alongside `markSeen`, and the container gains `registerCatch` alongside `registerInPokedex`. Counting through `markSeen` would have inflated every total with re-registrations — and the shiny-propagation pass would have counted **every relative in an evolution chain**.

The alt-form trap I flagged during the schema work is closed: `registerCatch` counts the caught id and registers the base species *without* counting it. Catching Mega Charizard X is one catch, not two.

## Sprites are no longer stored

The URL is derived from the id. It was a 90-character string repeated on every entry — most of what a full Pokédex weighed, and it baked today's hot-linked host into every saved account. Exactly **one** consumer read it.

A one-time upgrade on load strips sprites and seeds pre-counting entries to **1**. One rather than zero deliberately: an entry exists because the Pokémon was obtained, so 1 is a floor rather than a fabrication, and a zero beside a caught marker reads as a bug. Idempotent, preserves won/shiny/mega.

## The tests caught a real off-by-one

`upsertSeenEntry` seeds a new entry at 1 — so `recordCatch` adding to that made **every first catch a two**. It now reads the count before upserting. Worth noting because the "seed to 1" default is what made it non-obvious.

## Existing specs changed — being explicit rather than quiet

Two asserted the stored sprite URL; two poked at a private `spriteCache`. The URL assertion is **retargeted** at the derivation function, which is where that behaviour now lives. The cache tests are **deleted**, because the cache is gone — a pure function of an integer doesn't need memoising.

Fixture literals elsewhere dropped an incidental `sprite` field; no assertions were weakened.

## UI

A `×N` badge on the Pokédex cell, shown only past one — a `×1` on every cell would be noise.