### PR TITLE
Badge dex: the lifetime trophy case

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,6 +5,7 @@ import { routes } from './app.routes';
 import { provideHttpClient, withXhr } from '@angular/common/http';
 import {
   bootstrapArrowRepeat,
+  bootstrapTrophy,
   bootstrapCheck,
   bootstrapClock,
   bootstrapController,
@@ -23,7 +24,9 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideIcons(
-      { bootstrapArrowRepeat,
+      {
+        bootstrapArrowRepeat,
+        bootstrapTrophy,
         bootstrapCheck,
         bootstrapClock,
         bootstrapController,

--- a/src/app/trainer-team/badge-dex/badge-dex.component.css
+++ b/src/app/trainer-team/badge-dex/badge-dex.component.css
@@ -1,0 +1,79 @@
+.badge-dex-total {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.region-case {
+  padding: 0.4rem 0.5rem;
+  border-radius: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+/* The region being played, so the case you are filling right now is findable. */
+.region-case.current-region {
+  outline: 2px solid rgba(255, 193, 7, 0.7);
+}
+
+.region-case.complete .region-count {
+  color: #2e9e4f;
+  font-weight: 700;
+}
+
+.region-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  margin-bottom: 0.15rem;
+}
+
+.region-name {
+  font-weight: 600;
+}
+
+.region-count {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+/* A round that offers a choice reads as one slot holding alternatives. */
+.badge-round {
+  display: flex;
+  gap: 0.15rem;
+  padding: 0.15rem;
+  border-radius: 0.35rem;
+}
+
+.badge-round.multi {
+  background: rgba(128, 128, 128, 0.18);
+}
+
+.badge-sprite {
+  width: 34px;
+  height: 34px;
+  object-fit: contain;
+  /* Unearned badges are present but drained, so the shape of what is left to
+     collect is visible without spoiling which badge it is. */
+  filter: grayscale(1);
+  opacity: 0.3;
+  transition: filter 0.2s ease, opacity 0.2s ease;
+}
+
+.badge-sprite.earned {
+  filter: none;
+  opacity: 1;
+}
+
+@media (max-width: 576px) {
+  .badge-sprite {
+    width: 28px;
+    height: 28px;
+  }
+}

--- a/src/app/trainer-team/badge-dex/badge-dex.component.html
+++ b/src/app/trainer-team/badge-dex/badge-dex.component.html
@@ -1,0 +1,51 @@
+<button type="button" class="btn"
+  [ngClass]="(darkMode | async) ? 'btn-outline-light' : 'btn-outline-dark'"
+  (click)="openBadgeDex()">
+  <ng-icon name="bootstrapTrophy"></ng-icon>
+  {{ 'badgeDex.button' | translate }}
+</button>
+
+<ng-template #badgeDexModal let-modal>
+  <div class="modal-header" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
+    <h4 class="modal-title">
+      {{ 'badgeDex.title' | translate }}
+      <small class="badge-dex-total">
+        {{ 'badgeDex.progress' | translate: { earned: earnedCount, total: totalBadges } }}
+      </small>
+    </h4>
+    <button type="button" class="btn-close"
+      [ngClass]="(darkMode | async) ? 'btn-close-white' : ''"
+      (click)="closeModal()" aria-label="Close"></button>
+  </div>
+
+  <div class="modal-body" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
+    @for (region of cases; track region.generationId) {
+      <section class="region-case"
+               [class.current-region]="region.generationId === currentGenerationId"
+               [class.complete]="isRegionComplete(region)">
+
+        <header class="region-header">
+          <span class="region-name">{{ region.region }}</span>
+          <span class="region-count">{{ earnedInRegion(region) }}/{{ region.rounds.length }}</span>
+        </header>
+
+        <div class="badge-row">
+          @for (round of region.rounds; track $index) {
+            <div class="badge-round" [class.multi]="round.badges.length > 1">
+              @for (badge of round.badges; track badge.name) {
+                <img [src]="badge.sprite"
+                     appImageFallback
+                     loading="lazy"
+                     class="badge-sprite"
+                     [class.earned]="hasBadge(badge)"
+                     placement="bottom"
+                     [ngbTooltip]="hasBadge(badge) ? (badge.name | translate) : '???'"
+                     [alt]="hasBadge(badge) ? (badge.name | translate) : '???'">
+              }
+            </div>
+          }
+        </div>
+      </section>
+    }
+  </div>
+</ng-template>

--- a/src/app/trainer-team/badge-dex/badge-dex.component.spec.ts
+++ b/src/app/trainer-team/badge-dex/badge-dex.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+import { provideIcons } from '@ng-icons/core';
+import { bootstrapTrophy } from '@ng-icons/bootstrap-icons';
+
+import { BadgeDexComponent } from './badge-dex.component';
+import { BadgeDexService } from '../../services/badge-dex-service/badge-dex.service';
+
+describe('BadgeDexComponent', () => {
+  let fixture: ComponentFixture<BadgeDexComponent>;
+  let component: BadgeDexComponent;
+  let badgeDex: BadgeDexService;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+
+    await TestBed.configureTestingModule({
+      imports: [BadgeDexComponent],
+      providers: [provideTranslateService(), provideIcons({ bootstrapTrophy })],
+    }).compileComponents();
+
+    badgeDex = TestBed.inject(BadgeDexService);
+    fixture = TestBed.createComponent(BadgeDexComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterAll(() => localStorage.clear());
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('shows every region', () => {
+    expect(component.cases.length).toBe(9);
+  });
+
+  it('groups a region into its eight gyms', () => {
+    for (const region of component.cases) {
+      expect(region.rounds.length)
+        .withContext(`${region.region} should have eight rounds`)
+        .toBe(8);
+    }
+  });
+
+  it('counts every badge in the game, alternatives included', () => {
+    expect(component.totalBadges).toBe(77);
+  });
+
+  it('starts with nothing earned', () => {
+    expect(component.earnedCount).toBe(0);
+    expect(component.cases.every(region => !component.isRegionComplete(region))).toBeTrue();
+  });
+
+  it('marks a badge once it has been earned', () => {
+    const kanto = component.cases[0];
+    const first = kanto.rounds[0].badges[0];
+
+    expect(component.hasBadge(first)).toBeFalse();
+
+    badgeDex.record(first);
+    fixture.detectChanges();
+
+    expect(component.hasBadge(first)).toBeTrue();
+    expect(component.earnedInRegion(kanto)).toBe(1);
+  });
+
+  // A round offering a choice is satisfied by any one of its badges — you can
+  // only win one per run, and beating the gym is what counts.
+  it('counts a round complete with any one of its alternatives', () => {
+    const alola = component.cases.find(region => region.generationId === 7)!;
+    const choice = alola.rounds.find(round => round.badges.length > 1)!;
+
+    badgeDex.record(choice.badges[0]);
+    fixture.detectChanges();
+
+    expect(component.earnedInRegion(alola))
+      .withContext('one of the alternatives is the whole round')
+      .toBe(1);
+  });
+
+  it('calls a region complete only when every gym has yielded a badge', () => {
+    const kanto = component.cases[0];
+
+    for (const round of kanto.rounds.slice(0, 7)) {
+      badgeDex.record(round.badges[0]);
+    }
+    fixture.detectChanges();
+    expect(component.isRegionComplete(kanto))
+      .withContext('seven of eight is not the Victory Road')
+      .toBeFalse();
+
+    badgeDex.record(kanto.rounds[7].badges[0]);
+    fixture.detectChanges();
+    expect(component.isRegionComplete(kanto)).toBeTrue();
+  });
+});

--- a/src/app/trainer-team/badge-dex/badge-dex.component.ts
+++ b/src/app/trainer-team/badge-dex/badge-dex.component.ts
@@ -1,0 +1,119 @@
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgIconsModule } from '@ng-icons/core';
+import { NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { Observable, Subscription } from 'rxjs';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { ThemeService } from '../../services/theme-service/theme.service';
+import { GenerationService } from '../../services/generation-service/generation.service';
+import { BadgeDexService, ALL_BADGE_IDS, badgeId } from '../../services/badge-dex-service/badge-dex.service';
+import { badgesByGeneration } from '../../services/badges-service/badges-data';
+import { Badge } from '../../interfaces/badge';
+import { ImageFallbackDirective } from '../../directives/image-fallback.directive';
+
+/** One gym's worth of badges. More than one when the region offers a choice. */
+interface BadgeRound {
+  readonly badges: readonly Badge[];
+}
+
+interface RegionCase {
+  readonly generationId: number;
+  readonly region: string;
+  readonly rounds: readonly BadgeRound[];
+}
+
+/**
+ * The lifetime badge collection — a trophy case, not a Pokédex.
+ *
+ * Grouped by region and by gym rather than laid out as a flat grid: 77 badges
+ * across nine regions have real structure, and "which gyms have I beaten in
+ * Kanto" is the question someone actually has.
+ */
+@Component({
+  selector: 'app-badge-dex',
+  imports: [CommonModule, NgIconsModule, NgbTooltipModule, TranslatePipe, ImageFallbackDirective],
+  templateUrl: './badge-dex.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  styleUrl: './badge-dex.component.css',
+})
+export class BadgeDexComponent implements OnInit, OnDestroy {
+
+  constructor(
+    private themeService: ThemeService,
+    private modalService: NgbModal,
+    private badgeDexService: BadgeDexService,
+    private generationService: GenerationService,
+  ) {}
+
+  // static: true, or the first click finds an undefined ref — same reason as
+  // the Pokédex modal next to it.
+  @ViewChild('badgeDexModal', { static: true }) badgeDexModal!: TemplateRef<unknown>;
+
+  darkMode!: Observable<boolean>;
+  earned: ReadonlySet<string> = new Set();
+  currentGenerationId = 1;
+
+  /**
+   * Built in ngOnInit, not as a field initialiser: those run before constructor
+   * parameter properties are assigned, so `this.generationService` would be
+   * undefined. It broke the parent component's spec, not just this one's.
+   */
+  cases: readonly RegionCase[] = [];
+  readonly totalBadges = ALL_BADGE_IDS.size;
+
+  private readonly subscriptions = new Subscription();
+
+  ngOnInit(): void {
+    this.darkMode = this.themeService.isDark$;
+    this.cases = this.buildCases();
+
+    this.subscriptions.add(
+      this.badgeDexService.earned$.subscribe(earned => (this.earned = earned)),
+    );
+    this.subscriptions.add(
+      this.generationService.getGeneration().subscribe(generation => {
+        this.currentGenerationId = generation.id;
+      }),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  get earnedCount(): number {
+    return this.earned.size;
+  }
+
+  hasBadge(badge: Badge): boolean {
+    return this.earned.has(badgeId(badge));
+  }
+
+  /** A region counts as complete when every round has yielded a badge. */
+  isRegionComplete(region: RegionCase): boolean {
+    return region.rounds.every(round => round.badges.some(badge => this.hasBadge(badge)));
+  }
+
+  earnedInRegion(region: RegionCase): number {
+    return region.rounds.filter(round => round.badges.some(badge => this.hasBadge(badge))).length;
+  }
+
+  openBadgeDex(): void {
+    this.modalService.open(this.badgeDexModal, { centered: true, size: 'lg', scrollable: true });
+  }
+
+  closeModal(): void {
+    this.modalService.dismissAll();
+  }
+
+  private buildCases(): RegionCase[] {
+    return this.generationService.getGenerationList().map(generation => ({
+      generationId: generation.id,
+      region: generation.region,
+      rounds: (badgesByGeneration[generation.id] ?? []).map(round => ({
+        badges: Array.isArray(round) ? round : [round],
+      })),
+    }));
+  }
+}

--- a/src/app/trainer-team/trainer-team.component.html
+++ b/src/app/trainer-team/trainer-team.component.html
@@ -46,6 +46,7 @@
                <div class="col-12 p-0 d-flex flex-column flex-md-row gap-2">
                     <app-storage-pc></app-storage-pc>
                     <app-pokedex></app-pokedex>
+                    <app-badge-dex></app-badge-dex>
                </div>
           </div>
     </div>

--- a/src/app/trainer-team/trainer-team.component.ts
+++ b/src/app/trainer-team/trainer-team.component.ts
@@ -9,6 +9,7 @@ import { Badge } from '../interfaces/badge';
 import { TrainerService } from '../services/trainer-service/trainer.service';
 import { StoragePcComponent } from "./storage-pc/storage-pc.component";
 import { PokedexComponent } from "./pokedex/pokedex.component";
+import { BadgeDexComponent } from "./badge-dex/badge-dex.component";
 import {TranslatePipe} from '@ngx-translate/core';
 import { ItemItem } from '../interfaces/item-item';
 import { ImageFallbackDirective } from '../directives/image-fallback.directive';
@@ -19,7 +20,7 @@ import { ImageFallbackDirective } from '../directives/image-fallback.directive';
     ImageFallbackDirective,CommonModule,
     NgbTooltipModule,
     BadgesComponent,
-    StoragePcComponent, TranslatePipe, PokedexComponent],
+    StoragePcComponent, TranslatePipe, PokedexComponent, BadgeDexComponent],
   templateUrl: './trainer-team.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrls: ['./trainer-team.component.css']

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2827,6 +2827,11 @@
     },
     "caught": "Gefangen:"
   },
+  "badgeDex": {
+    "button": "Orden",
+    "title": "Ordensetui",
+    "progress": "{{earned}} von {{total}}"
+  },
   "detail": {
     "name": "Name",
     "types": "Typen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2827,6 +2827,11 @@
     },
     "caught": "Caught:"
   },
+  "badgeDex": {
+    "button": "Badges",
+    "title": "Badge Case",
+    "progress": "{{earned}} of {{total}}"
+  },
   "detail": {
     "name": "Name",
     "types": "Types",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2827,6 +2827,11 @@
     },
     "caught": "Capturados:"
   },
+  "badgeDex": {
+    "button": "Medallas",
+    "title": "Estuche de Medallas",
+    "progress": "{{earned}} de {{total}}"
+  },
   "detail": {
     "name": "Nombre",
     "types": "Tipos",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -2827,6 +2827,11 @@
     },
     "caught": "Capturés :"
   },
+  "badgeDex": {
+    "button": "Badges",
+    "title": "Boîte à Badges",
+    "progress": "{{earned}} sur {{total}}"
+  },
   "detail": {
     "name": "Nom",
     "types": "Types",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2827,6 +2827,11 @@
     },
     "caught": "Catturati:"
   },
+  "badgeDex": {
+    "button": "Medaglie",
+    "title": "Custodia Medaglie",
+    "progress": "{{earned}} su {{total}}"
+  },
   "detail": {
     "name": "Nome",
     "types": "Tipi",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2827,6 +2827,11 @@
     },
     "caught": "Capturados:"
   },
+  "badgeDex": {
+    "button": "Insígnias",
+    "title": "Estojo de Insígnias",
+    "progress": "{{earned}} de {{total}}"
+  },
   "detail": {
     "name": "Nome",
     "types": "Tipos",


### PR DESCRIPTION
Closes #54. The data landed with #49; this is the view.

451/451 tests, build green, i18n parity holds at 2234 keys.

## Grouped by region and gym, not a flat grid

Seventy-seven badges across nine regions have real structure, and **"which gyms have I beaten in Kanto"** is the question someone actually has — a Pokédex-style wall of icons answers a different one. Unearned badges show *drained* rather than hidden, so the shape of what's left is visible without giving away which badge it is.

A round offering a choice (Alola's Z-crystals) renders as **one slot holding alternatives**, and counts complete when any one is held — you can only win one per run, and beating the gym is what the count is about. That matches how the achievements read it.

The region currently being played is outlined, so the case you're filling right now is findable among nine.

## Two bugs the tests caught

**One wasn't confined to tests.** `cases` was a field initialiser calling a method that reads `this.generationService` — and **field initialisers run before constructor parameter properties are assigned**, so it read `undefined`. It surfaced by breaking the *parent* component's spec, which is a good argument for those existing. Built in `ngOnInit` now.

**The other was me inventing a convention.** I declared icons with a component-level `provideIcons`. Every other component here relies on `app.config` providing them globally, with specs supplying their own. Now following that.

## i18n

Three new strings across all six locales, in the per-locale house style for badges — Insígnias / Medallas / Badges / Orden / Medaglie. Badge *names* needed nothing new: all 77 already exist in every locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)