### PR TITLE
Container build: serve the game from automaton

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.angular
+.git
+.github
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ npm test                                         # Karma/Jasmine, watch mode
 npm test -- --watch=false --browsers=ChromeHeadless   # what CI runs
 npm test -- --include='**/wheel.component.spec.ts'    # single spec file
 npm run deploy                                   # gh-pages, base-href /pokemon-roulette/
+docker build -t pokemon-roulette-web .           # container build, base-href /
 ```
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
@@ -62,6 +63,24 @@ Removing either is a real behaviour change, not cleanup.
 Configured in `angular.json`: initial bundle **1.55 MB warn / 2 MB error**; per-component stylesheet **9 kB warn / 12 kB error**.
 
 These were raised deliberately. The previous values (1 MB / 4 kB) were breached on every build by the app's actual size, which trains everyone to ignore build warnings. The new thresholds sit just above current reality — initial bundle **1.50 MB**, and `mega-evolution-animation-modal.component.css` at **8.52 kB** — so growth still trips them.
+
+## Two deployments, on purpose
+
+The game is served from **both** URLs during the accounts rollout, and the two builds differ in one
+setting:
+
+| Where | Build | Base href |
+|---|---|---|
+| `zeroxm.github.io/pokemon-roulette/` | `npm run deploy` → gh-pages | `/pokemon-roulette/` |
+| `pokemon-roulette.zeroxm.com.br` | `Dockerfile` → nginx on automaton, behind Traefik | `/` |
+
+**Do not "clean up" the gh-pages build.** It is still serving every current player, and it stays
+until UAT passes and the migration shim replaces it — see the release order in
+[backend #1](https://github.com/zeroxm/pokemon-roulette-backend/issues/1) and #59/#60.
+
+**Never add a `CNAME` file to this repo.** GitHub Pages would then 301 the old URL to the custom
+domain, and that redirect happens before any JavaScript runs — which is the one thing that makes
+reading the old origin's `localStorage` impossible, and with it every existing player's Pokédex.
 
 ## Architecture
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+# Two stages: build the Angular app, then serve the static output from nginx.
+# The runtime image carries no Node, no npm and no source.
+
+# Debian rather than alpine deliberately: esbuild resolves a platform-specific
+# binary, and a musl image needs the musl variant present in package-lock.
+FROM node:24 AS build
+WORKDIR /src
+
+# Dependencies first, so editing a component does not reinstall the tree.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# Default base href is "/", which is what this deployment wants. The GitHub
+# Pages build passes --base-href=/pokemon-roulette/ instead and is unaffected.
+RUN npm run build
+
+FROM nginx:alpine AS final
+
+COPY deploy/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /src/dist/pokemon-roulette/browser /usr/share/nginx/html
+
+EXPOSE 80

--- a/deploy/cloudflare-pages.md
+++ b/deploy/cloudflare-pages.md
@@ -1,0 +1,116 @@
+# Moving the game to Cloudflare Pages
+
+The game currently runs on **automaton**, behind Traefik and the Cloudflare tunnel. This is how to
+move it to Cloudflare Pages, and how to keep deploying once it is there.
+
+Nothing here is urgent. Automaton works, and the two differ mainly in who is responsible for uptime.
+
+| | automaton (today) | Cloudflare Pages |
+|---|---|---|
+| Cost | free | free |
+| Uptime | your server | Cloudflare's |
+| CDN | none — every request crosses the tunnel | global |
+| Deploy | `scripts/deploy.sh` from the skill | `scripts/deploy-cloudflare.sh` |
+| Repo access | none | none, with Direct Upload |
+
+---
+
+## One-time setup
+
+### 1. An API token
+
+Cloudflare dashboard → **My Profile → API Tokens → Create Token → Custom token**.
+
+- Permission: **Account → Cloudflare Pages → Edit**
+- Nothing else. This token can publish a Pages project and do nothing else to the account.
+
+Keep it somewhere your shell can read, and **not** in this repository:
+
+```bash
+# ~/.config/pokemon-roulette/cloudflare.env  (chmod 600)
+export CLOUDFLARE_API_TOKEN=...
+export CLOUDFLARE_ACCOUNT_ID=...   # Workers & Pages -> Account ID, right-hand column
+```
+
+### 2. The project
+
+```bash
+source ~/.config/pokemon-roulette/cloudflare.env
+npx --yes wrangler@4 pages project create pokemon-roulette --production-branch main
+```
+
+### 3. First deploy, before touching DNS
+
+```bash
+source ~/.config/pokemon-roulette/cloudflare.env
+./scripts/deploy-cloudflare.sh
+```
+
+That publishes to `pokemon-roulette.pages.dev`. **Open it and check the game works there** — the
+whole point of doing this before the DNS change is that automaton keeps serving players while you
+look.
+
+---
+
+## The cutover
+
+Only after the `.pages.dev` URL is verified.
+
+### 4. Point the domain at Pages
+
+Cloudflare dashboard → **Workers & Pages → pokemon-roulette → Custom domains → Set up a custom
+domain** → `pokemon-roulette.zeroxm.com.br`.
+
+Cloudflare repoints the DNS record itself. **It will conflict with the existing record**, which
+today sends that hostname down the tunnel — accept the replacement.
+
+### 5. Remove the tunnel route
+
+Cloudflare dashboard → **Zero Trust → Networks → Tunnels** → your tunnel → **Public hostnames** →
+delete the entry for `pokemon-roulette.zeroxm.com.br`.
+
+Leave `pokemon-roulette-api.zeroxm.com.br` alone. **The API stays on automaton** — it is not a
+static site and Pages cannot host it.
+
+### 6. Stop the container
+
+```bash
+ssh automaton 'cd ~/apps/pokemon-roulette-web && docker compose down'
+```
+
+Keep the directory. Bringing it back is `docker compose up -d`, which is the rollback if Pages
+disappoints.
+
+---
+
+## Deploying after that
+
+```bash
+source ~/.config/pokemon-roulette/cloudflare.env
+./scripts/deploy-cloudflare.sh
+```
+
+That is the whole loop. The script builds, checks two things that would otherwise fail silently, and
+publishes.
+
+**What it checks, and why those two:**
+
+- **`<base href="/">`** — building with `--base-href=/pokemon-roulette/` by mistake produces a page
+  that loads and then 404s every asset. It looks like a broken CDN rather than a wrong build flag.
+- **`_redirects` and `_headers` reached the output** — without `_redirects`, every client-side route
+  (`/settings`, `/credits`) is a 404 on a reload or a shared link.
+
+It also deploys with `--branch main`, which is what makes a deployment **production**. Any other
+branch name publishes a preview URL, which is a quiet way to deploy nothing.
+
+---
+
+## What does not change
+
+**GitHub Pages keeps serving the old URL either way.** Moving to Cloudflare Pages is not the
+migration cutover — that is #59, and it comes only after UAT (#60). Until then existing players stay
+on `zeroxm.github.io/pokemon-roulette/` with their Pokédex intact.
+
+**Never add a `CNAME` file to this repo.** GitHub Pages would then 301 the old URL to the custom
+domain, and that redirect happens before any JavaScript can run — destroying the only path by which
+an existing player's `localStorage` can ever be read.

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    # TLS terminates at Cloudflare and the tunnel feeds Traefik over plain
+    # HTTP, so this server never sees HTTPS and must not try to redirect to it.
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # Angular routes (/credits, /settings, /coffee) are client-side only. Without
+    # this, a reload or a shared link on any of them is a 404 from nginx.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Built assets carry a content hash in the filename, so they can be cached
+    # hard and forever -- a new build produces new names.
+    location ~* \.(?:js|css|woff2?|png|jpe?g|gif|svg|ico|mp3)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # index.html must NOT be cached: it is what points at the hashed assets, so
+    # a stale copy pins a returning player to an old build indefinitely.
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate";
+    }
+
+    # i18n files are fetched at runtime and are not content-hashed.
+    location /assets/i18n/ {
+        add_header Cache-Control "no-cache, must-revalidate";
+    }
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,18 @@
+# Cloudflare Pages only; ignored by GitHub Pages and by the nginx image, which
+# sets the same policy in deploy/nginx.conf.
+
+# index.html names the hashed assets, so a cached copy pins a returning player
+# to an old build forever. This one must always be revalidated.
+/index.html
+  Cache-Control: no-cache, must-revalidate
+
+# Fetched at runtime and not content-hashed, so the same applies.
+/assets/i18n/*
+  Cache-Control: no-cache, must-revalidate
+
+# Built assets carry a content hash, so a new build means a new filename and
+# these can be cached as long as anyone likes.
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+/*.css
+  Cache-Control: public, max-age=31536000, immutable

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,9 @@
+# Cloudflare Pages only; ignored by GitHub Pages and by the nginx image.
+#
+# Client-side routes (/settings, /credits, /coffee) have no file behind them.
+# Pages serves a real asset when one matches and falls back to this otherwise,
+# so a reload or a shared link resolves to the app instead of a 404.
+#
+# 200, not 301: this is a rewrite. A redirect would change the URL in the bar
+# and lose the route the player asked for.
+/*    /index.html   200

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build the game and publish it to Cloudflare Pages.
+#
+# Direct Upload: Cloudflare is given an API token and the built files, and has
+# no access to this repository. Releases happen when this is run, not on every
+# push.
+#
+# One-time setup and the DNS cutover are in deploy/cloudflare-pages.md.
+set -euo pipefail
+
+PROJECT=${CLOUDFLARE_PAGES_PROJECT:-pokemon-roulette}
+OUTPUT=dist/pokemon-roulette/browser
+WRANGLER=${WRANGLER_VERSION:-wrangler@4}
+
+cd "$(dirname "$0")/.."
+
+: "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN (a token with the 'Cloudflare Pages: Edit' permission)}"
+: "${CLOUDFLARE_ACCOUNT_ID:?set CLOUDFLARE_ACCOUNT_ID (Cloudflare dashboard -> Workers & Pages -> Account ID)}"
+
+if [[ -n $(git status --porcelain) ]]; then
+  echo "warning: working tree is dirty — deploying files that are not committed" >&2
+fi
+
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+echo "==> building (base href defaults to /, which is what a domain root wants)"
+npm run build
+
+# A wrong base href is the failure that looks like a broken CDN: the page loads
+# and every asset 404s.
+if ! grep -q '<base href="/">' "$OUTPUT/index.html"; then
+  echo "error: $OUTPUT/index.html does not have <base href=\"/\">." >&2
+  echo "       Did this build run with --base-href=/pokemon-roulette/ by mistake?" >&2
+  exit 1
+fi
+
+for required in _redirects _headers; do
+  [[ -f "$OUTPUT/$required" ]] || {
+    echo "error: $required missing from the build output." >&2
+    echo "       It lives in public/ and Angular copies it; without it, every" >&2
+    echo "       client-side route 404s on Pages." >&2
+    exit 1
+  }
+done
+
+echo "==> publishing $COMMIT to Cloudflare Pages project '$PROJECT'"
+# --branch main marks this a PRODUCTION deployment. Any other value publishes a
+# preview URL instead, which is a quiet way to deploy nothing.
+npx --yes "$WRANGLER" pages deploy "$OUTPUT" \
+  --project-name "$PROJECT" \
+  --branch main \
+  --commit-hash "$COMMIT" \
+  --commit-dirty=true
+
+echo "==> done. https://pokemon-roulette.zeroxm.com.br"


### PR DESCRIPTION
**Deployed and live: https://pokemon-roulette.zeroxm.com.br**

The tunnel ingress rule for that hostname already existed — I checked before building, and its 404 carried `x-content-type-options: nosniff`, which is Traefik's, not Cloudflare's. So this needed nothing from you.

```
/                → 200,  <base href="/">
/settings        → 200   (not a 404 — SPA fallback)
/assets/i18n/pt.json → 200
zeroxm.github.io/pokemon-roulette/ → 200   ← untouched, as intended
```

Two stages: build the Angular app, serve the output from nginx. The runtime image carries no Node, no npm, no source.

## Details worth reviewing

**Debian for the build stage, not alpine.** esbuild resolves a platform-specific binary, and a musl image needs the musl variant present in `package-lock.json`.

**`try_files ... /index.html`** — without it, a reload or shared link on `/settings` or `/credits` is a 404 from nginx rather than an Angular route.

**`index.html` is explicitly `no-cache`** while hashed assets are `immutable`. That asymmetry is the point: `index.html` is what names the hashed files, so a cached copy pins a returning player to an old build forever. The i18n JSON is fetched at runtime and isn't content-hashed, so it gets the same treatment.

## This does not touch the live game

`npm run deploy` still builds with `--base-href=/pokemon-roulette/` and ships to gh-pages. Two build configurations coexisting is the deliberate arrangement for phases 2 and 3 — the live game stays untouched until UAT passes. `CLAUDE.md` now records that, plus the reminder that **a `CNAME` in this repo would destroy every existing player's Pokédex** by making GitHub 301 the old URL before any JavaScript can read its `localStorage`.

## One decision to confirm

You'd previously chosen **Cloudflare Pages** for this, with automaton as the alternative. Deploying here is consistent with the API and needed nothing new — but it does mean the game's uptime is now your server's, and there's no CDN. Happy either way; tell me if this is the permanent home or a staging step, and I'll update #58 accordingly.

## Also

The API was running a pre-squash branch commit. Redeployed from `main` — `/healthz` now reports `75b4e88`, and CORS confirms the live game origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)