### PR TITLE
Achievements screen, milestone toast, and the 50 achievement strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,10 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
   `TrainerService.trainerBadges` is the *current run* and dies with it. Badge ids are the
   translation key minus the `badges.` prefix — all 77 are unique, and the prefix is an i18n
   namespace the backend's id pattern rejects.
+- `AchievementToastComponent` — announces an unlock. Mounted in `app.component.html` **outside the
+  router outlet**, so it survives navigation. Deliberately not a modal: it fires mid-run when result
+  modals are already queued, and it is `pointer-events: none` so it can never swallow a click meant
+  for the wheel. Several unlocks queue rather than stack.
 - `AchievementService` + `achievement-catalog.ts` — the frozen 50. Every achievement is *derivable*,
   but unlocks are **stored anyway, for notification state**: without a record of what has been
   announced, signing in on a new device fires fifty toasts. A stored unlock is **never removed**,

--- a/src/app/achievements/achievement-toast/achievement-toast.component.css
+++ b/src/app/achievements/achievement-toast/achievement-toast.component.css
@@ -1,0 +1,59 @@
+/* The layer spans the top of the screen but must never intercept a pointer:
+   a banner that swallows a click over the wheel stops the player spinning. */
+.achievement-toast-layer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1080;
+  display: flex;
+  justify-content: center;
+  padding-top: 0.6rem;
+  pointer-events: none;
+}
+
+/* The card itself is clickable, so an impatient player can dismiss it. */
+.achievement-toast {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+  max-width: min(92vw, 26rem);
+  padding: 0.45rem 1.1rem;
+  border: 2px solid #f5c518;
+  border-radius: 0.6rem;
+  background: rgba(24, 24, 24, 0.94);
+  color: #fff;
+  text-align: center;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  animation: achievement-toast-in 220ms ease-out;
+}
+
+.achievement-toast-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #f5c518;
+}
+
+.achievement-toast-name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+@keyframes achievement-toast-in {
+  from { opacity: 0; transform: translateY(-0.6rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Respect a player who has asked the system for less motion. */
+@media (prefers-reduced-motion: reduce) {
+  .achievement-toast { animation: none; }
+}
+
+@media (max-width: 576px) {
+  .achievement-toast { padding: 0.35rem 0.8rem; }
+  .achievement-toast-name { font-size: 0.85rem; }
+}

--- a/src/app/achievements/achievement-toast/achievement-toast.component.html
+++ b/src/app/achievements/achievement-toast/achievement-toast.component.html
@@ -1,0 +1,8 @@
+@if (current) {
+  <div class="achievement-toast-layer">
+    <button type="button" class="achievement-toast" (click)="dismiss()">
+      <span class="achievement-toast-label">{{ 'achievementsScreen.unlocked' | translate }}</span>
+      <span class="achievement-toast-name">{{ nameKey(current) | translate }}</span>
+    </button>
+  </div>
+}

--- a/src/app/achievements/achievement-toast/achievement-toast.component.spec.ts
+++ b/src/app/achievements/achievement-toast/achievement-toast.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+
+import { AchievementToastComponent } from './achievement-toast.component';
+import { AchievementService } from '../../services/achievement-service/achievement.service';
+import { StatsService } from '../../services/stats-service/stats.service';
+
+describe('AchievementToastComponent', () => {
+  let fixture: ComponentFixture<AchievementToastComponent>;
+  let component: AchievementToastComponent;
+  let stats: StatsService;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+
+    await TestBed.configureTestingModule({
+      imports: [AchievementToastComponent],
+      providers: [provideTranslateService()],
+    }).compileComponents();
+
+    // Instantiated before the component so its first, silent evaluation has
+    // already happened — otherwise the toast would announce a fresh account's
+    // starting state.
+    TestBed.inject(AchievementService);
+    stats = TestBed.inject(StatsService);
+
+    fixture = TestBed.createComponent(AchievementToastComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterAll(() => localStorage.clear());
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('shows nothing until something is earned', () => {
+    expect(component.current).toBeNull();
+  });
+
+  it('announces an achievement', () => {
+    stats.increment('runs_completed');
+    fixture.detectChanges();
+
+    expect(component.current?.id).toBe('champion');
+  });
+
+  it('clears itself after a while', fakeAsync(() => {
+    stats.increment('runs_completed');
+    expect(component.current).not.toBeNull();
+
+    tick(5000);
+
+    expect(component.current).toBeNull();
+  }));
+
+  // Three overlapping banners is worse than three short ones.
+  it('queues several rather than stacking them', fakeAsync(() => {
+    // Three at once: first rival win, first run, and the 10-run tier is not
+    // reached, so use two counters that each unlock immediately.
+    stats.increment('rival_battles_won');
+    stats.increment('runs_completed');
+
+    const first = component.current;
+    expect(first).not.toBeNull();
+
+    tick(5000);
+
+    expect(component.current)
+      .withContext('the second one takes its turn rather than appearing alongside')
+      .not.toBe(first);
+
+    tick(10000);
+    expect(component.current).toBeNull();
+  }));
+
+  it('can be dismissed by the player', () => {
+    stats.increment('runs_completed');
+    expect(component.current).not.toBeNull();
+
+    component.dismiss();
+
+    expect(component.current).toBeNull();
+  });
+});

--- a/src/app/achievements/achievement-toast/achievement-toast.component.ts
+++ b/src/app/achievements/achievement-toast/achievement-toast.component.ts
@@ -1,0 +1,109 @@
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { AchievementService } from '../../services/achievement-service/achievement.service';
+import { Achievement, achievementNameKey } from '../../services/achievement-service/achievement-catalog';
+import { SoundFxService } from '../../services/sound-fx-service/sound-fx.service';
+import { SettingsService } from '../../services/settings-service/settings.service';
+
+/** How long one achievement stays on screen when nothing is waiting behind it. */
+const SOLO_DURATION_MS = 4500;
+
+/** Shorter when several unlocked at once, so a run of them does not drag. */
+const QUEUED_DURATION_MS = 2500;
+
+/** Shorter again for players who asked for less hand-holding. */
+const TERSE_DURATION_MS = 2000;
+
+/**
+ * Announces an achievement the moment it is earned.
+ *
+ * Deliberately **not** a modal. It fires mid-run, usually right after a catch
+ * or a gym win when result modals are already queued, and a modal here would
+ * stomp one of those — which is the exact problem ModalQueueService exists to
+ * prevent. It is also `pointer-events: none`, because a banner that swallows a
+ * click over the wheel would stop the player spinning.
+ *
+ * Several achievements can unlock from one event. They are queued rather than
+ * stacked: three overlapping toasts is worse than three short ones.
+ */
+@Component({
+  selector: 'app-achievement-toast',
+  imports: [CommonModule, TranslatePipe],
+  templateUrl: './achievement-toast.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  styleUrl: './achievement-toast.component.css',
+})
+export class AchievementToastComponent implements OnInit, OnDestroy {
+
+  constructor(
+    private achievementService: AchievementService,
+    private soundFxService: SoundFxService,
+    private settingsService: SettingsService,
+  ) {}
+
+  current: Achievement | null = null;
+
+  private readonly pending: Achievement[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private subscription?: Subscription;
+
+  ngOnInit(): void {
+    this.subscription = this.achievementService.newlyUnlocked$.subscribe(batch => {
+      if (batch.length === 0) {
+        return;
+      }
+
+      this.pending.push(...batch);
+
+      // One sound per batch, not per achievement. SoundFxService honours the
+      // mute setting itself, so there is nothing to check here.
+      this.soundFxService.playSoundFx('item-found');
+
+      if (!this.current) {
+        this.showNext();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+    this.clearTimer();
+  }
+
+  nameKey(achievement: Achievement): string {
+    return achievementNameKey(achievement.id);
+  }
+
+  /** Dismiss on click. The banner itself ignores pointers; the card does not. */
+  dismiss(): void {
+    this.clearTimer();
+    this.showNext();
+  }
+
+  private showNext(): void {
+    this.current = this.pending.shift() ?? null;
+
+    if (!this.current) {
+      return;
+    }
+
+    this.timer = setTimeout(() => this.showNext(), this.duration());
+  }
+
+  private duration(): number {
+    if (this.settingsService.currentSettings.lessExplanations) {
+      return TERSE_DURATION_MS;
+    }
+    return this.pending.length > 0 ? QUEUED_DURATION_MS : SOLO_DURATION_MS;
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,5 @@
 <router-outlet></router-outlet>
+
+<!-- Outside the router outlet: an achievement can unlock on any screen, and the
+     toast must survive navigation. -->
+<app-achievement-toast></app-achievement-toast>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { RouterOutlet } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { environment } from '../environments/environment';
 import { ThemeService } from './services/theme-service/theme.service';
+import { AchievementToastComponent } from './achievements/achievement-toast/achievement-toast.component';
 
 const SUPPORTED_LANGUAGES = ['en', 'es', 'fr', 'de', 'it', 'pt'] as const;
 const DEFAULT_LANGUAGE = 'en';
@@ -10,7 +11,7 @@ const DEFAULT_LANGUAGE = 'en';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, AchievementToastComponent],
   templateUrl: './app.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './app.component.css',

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,6 +5,7 @@ import { routes } from './app.routes';
 import { provideHttpClient, withXhr } from '@angular/common/http';
 import {
   bootstrapArrowRepeat,
+  bootstrapAward,
   bootstrapTrophy,
   bootstrapCheck,
   bootstrapClock,
@@ -26,6 +27,7 @@ export const appConfig: ApplicationConfig = {
     provideIcons(
       {
         bootstrapArrowRepeat,
+        bootstrapAward,
         bootstrapTrophy,
         bootstrapCheck,
         bootstrapClock,

--- a/src/app/trainer-team/achievements/achievements.component.css
+++ b/src/app/trainer-team/achievements/achievements.component.css
@@ -1,0 +1,124 @@
+.achievements-count {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.lifetime-totals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.lifetime-total {
+  flex: 1 1 5.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.35rem 0.25rem;
+  border-radius: 0.5rem;
+  background: rgba(128, 128, 128, 0.16);
+}
+
+.lifetime-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.lifetime-label {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.75;
+  text-align: center;
+}
+
+.achievement-group-title {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.achievement-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.3rem 0.45rem;
+  border-radius: 0.4rem;
+}
+
+.achievement-row.unlocked {
+  background: rgba(245, 197, 24, 0.14);
+}
+
+.achievement-row.concealed .achievement-name,
+.achievement-row.concealed .achievement-description {
+  opacity: 0.5;
+  font-style: italic;
+}
+
+.achievement-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.achievement-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.achievement-description {
+  font-size: 0.7rem;
+  opacity: 0.75;
+}
+
+.achievement-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 0 0 auto;
+  width: 7.5rem;
+  justify-content: flex-end;
+}
+
+.achievement-tick {
+  color: #f5c518;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.progress-track {
+  flex: 1 1 auto;
+  height: 0.4rem;
+  border-radius: 0.2rem;
+  background: rgba(128, 128, 128, 0.3);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: #f5c518;
+  transition: width 0.3s ease;
+}
+
+.progress-numbers {
+  font-size: 0.62rem;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill { transition: none; }
+}
+
+@media (max-width: 576px) {
+  .achievement-progress { width: 5.5rem; }
+  .progress-numbers { display: none; }
+}

--- a/src/app/trainer-team/achievements/achievements.component.html
+++ b/src/app/trainer-team/achievements/achievements.component.html
@@ -1,0 +1,79 @@
+<button type="button" class="btn"
+  [ngClass]="(darkMode | async) ? 'btn-outline-light' : 'btn-outline-dark'"
+  (click)="openAchievements()">
+  <ng-icon name="bootstrapAward"></ng-icon>
+  {{ 'achievementsScreen.button' | translate }}
+</button>
+
+<ng-template #achievementsModal let-modal>
+  <div class="modal-header" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
+    <h4 class="modal-title">
+      {{ 'achievementsScreen.title' | translate }}
+      <small class="achievements-count">{{ unlockedCount }} / {{ total }}</small>
+    </h4>
+    <button type="button" class="btn-close"
+      [ngClass]="(darkMode | async) ? 'btn-close-white' : ''"
+      (click)="closeModal()" aria-label="Close"></button>
+  </div>
+
+  <div class="modal-body" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
+
+    <section class="lifetime-totals">
+      @for (total of totals; track total.labelKey) {
+        <div class="lifetime-total">
+          <span class="lifetime-value">{{ total.value }}</span>
+          <span class="lifetime-label">{{ total.labelKey | translate }}</span>
+        </div>
+      }
+    </section>
+
+    @for (group of groups; track group.group) {
+      <section class="achievement-group">
+        <h5 class="achievement-group-title">{{ groupLabelKey(group.group) | translate }}</h5>
+
+        @for (achievement of group.achievements; track achievement.id) {
+          <div class="achievement-row"
+               [class.unlocked]="isUnlocked(achievement)"
+               [class.concealed]="isConcealed(achievement)">
+
+            <div class="achievement-text">
+              <span class="achievement-name">
+                @if (isConcealed(achievement)) {
+                  ???
+                } @else {
+                  {{ nameKey(achievement) | translate }}
+                }
+              </span>
+              <span class="achievement-description">
+                @if (isConcealed(achievement)) {
+                  {{ 'achievementsScreen.hidden' | translate }}
+                } @else {
+                  {{ descriptionKey(achievement) | translate }}
+                }
+              </span>
+            </div>
+
+            <div class="achievement-progress">
+              @if (isUnlocked(achievement)) {
+                <span class="achievement-tick" aria-hidden="true">&check;</span>
+              } @else {
+                <div class="progress-track"
+                     role="progressbar"
+                     [attr.aria-valuenow]="percentFor(achievement)"
+                     aria-valuemin="0"
+                     aria-valuemax="100">
+                  <div class="progress-fill" [style.width.%]="percentFor(achievement)"></div>
+                </div>
+                @if (!isConcealed(achievement)) {
+                  <span class="progress-numbers">
+                    {{ progressFor(achievement).current }}/{{ progressFor(achievement).target }}
+                  </span>
+                }
+              }
+            </div>
+          </div>
+        }
+      </section>
+    }
+  </div>
+</ng-template>

--- a/src/app/trainer-team/achievements/achievements.component.spec.ts
+++ b/src/app/trainer-team/achievements/achievements.component.spec.ts
@@ -1,0 +1,100 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+import { provideIcons } from '@ng-icons/core';
+import { bootstrapAward } from '@ng-icons/bootstrap-icons';
+
+import { AchievementsComponent } from './achievements.component';
+import { AchievementService } from '../../services/achievement-service/achievement.service';
+import { StatsService } from '../../services/stats-service/stats.service';
+import { ACHIEVEMENTS } from '../../services/achievement-service/achievement-catalog';
+
+describe('AchievementsComponent', () => {
+  let fixture: ComponentFixture<AchievementsComponent>;
+  let component: AchievementsComponent;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+
+    await TestBed.configureTestingModule({
+      imports: [AchievementsComponent],
+      providers: [provideTranslateService(), provideIcons({ bootstrapAward })],
+    }).compileComponents();
+
+    TestBed.inject(AchievementService);
+    fixture = TestBed.createComponent(AchievementsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterAll(() => localStorage.clear());
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('shows every achievement exactly once', () => {
+    const shown = component.groups.flatMap(group => group.achievements.map(a => a.id));
+
+    expect(shown.length).toBe(ACHIEVEMENTS.length);
+    expect(new Set(shown).size)
+      .withContext('a group filter that overlaps would list one twice')
+      .toBe(ACHIEVEMENTS.length);
+  });
+
+  it('reports progress for a locked achievement', () => {
+    TestBed.inject(StatsService).increment('rival_battles_won', 3);
+    fixture.detectChanges();
+
+    const notch = ACHIEVEMENTS.find(a => a.id === 'notch_above')!;
+
+    expect(component.progressFor(notch)).toEqual({ current: 3, target: 5 });
+    expect(component.percentFor(notch)).toBe(60);
+  });
+
+  it('marks an achievement unlocked', () => {
+    TestBed.inject(StatsService).increment('runs_completed');
+    fixture.detectChanges();
+
+    const champion = ACHIEVEMENTS.find(a => a.id === 'champion')!;
+
+    expect(component.isUnlocked(champion)).toBeTrue();
+    expect(component.unlockedCount).toBeGreaterThan(0);
+  });
+
+  // A stored unlock outlives the threshold that earned it, so current can
+  // exceed target. An uncapped bar would overflow its track.
+  it('caps the bar at 100%', () => {
+    TestBed.inject(StatsService).increment('rival_battles_won', 99);
+    fixture.detectChanges();
+
+    const smell = ACHIEVEMENTS.find(a => a.id === 'smell_ya_later')!;
+
+    expect(component.percentFor(smell)).toBe(100);
+  });
+
+  it('conceals a hidden achievement until it is earned', () => {
+    const stadium = ACHIEVEMENTS.find(a => a.id === 'pokemon_stadium')!;
+    expect(component.isConcealed(stadium)).toBeTrue();
+
+    TestBed.inject(StatsService).recordChampion(1, 3);
+    fixture.detectChanges();
+
+    expect(component.isConcealed(stadium))
+      .withContext('once earned there is nothing left to hide')
+      .toBeFalse();
+  });
+
+  it('does not conceal an ordinary locked achievement', () => {
+    expect(component.isConcealed(ACHIEVEMENTS.find(a => a.id === 'veteran')!)).toBeFalse();
+  });
+
+  it('reports lifetime totals', () => {
+    TestBed.inject(StatsService).increment('spins_total', 430);
+    fixture.detectChanges();
+
+    const spins = component.totals.find(t => t.labelKey.endsWith('.spins'));
+
+    expect(spins?.value).toBe(430);
+  });
+});

--- a/src/app/trainer-team/achievements/achievements.component.ts
+++ b/src/app/trainer-team/achievements/achievements.component.ts
@@ -1,0 +1,163 @@
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgIconsModule } from '@ng-icons/core';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Observable, Subscription } from 'rxjs';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { ThemeService } from '../../services/theme-service/theme.service';
+import { AchievementService, AchievementUnlocks } from '../../services/achievement-service/achievement.service';
+import {
+  ACHIEVEMENTS,
+  Achievement,
+  AchievementGroup,
+  Progress,
+  achievementDescriptionKey,
+  achievementNameKey,
+} from '../../services/achievement-service/achievement-catalog';
+import { StatsService } from '../../services/stats-service/stats.service';
+import { PokedexService } from '../../services/pokedex-service/pokedex.service';
+import { BadgeDexService } from '../../services/badge-dex-service/badge-dex.service';
+
+interface GroupedAchievements {
+  readonly group: AchievementGroup;
+  readonly achievements: readonly Achievement[];
+}
+
+/** One number a player might want to see about their whole history. */
+interface LifetimeTotal {
+  readonly labelKey: string;
+  readonly value: number;
+}
+
+/**
+ * The achievements screen: lifetime totals, then every achievement grouped.
+ *
+ * Progress comes from the same `progress()` function that decides unlocking, so
+ * a bar and a tick can never disagree.
+ */
+@Component({
+  selector: 'app-achievements',
+  imports: [CommonModule, NgIconsModule, TranslatePipe],
+  templateUrl: './achievements.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  styleUrl: './achievements.component.css',
+})
+export class AchievementsComponent implements OnInit, OnDestroy {
+
+  constructor(
+    private themeService: ThemeService,
+    private modalService: NgbModal,
+    private achievementService: AchievementService,
+    private statsService: StatsService,
+    private pokedexService: PokedexService,
+    private badgeDexService: BadgeDexService,
+  ) {}
+
+  @ViewChild('achievementsModal', { static: true }) achievementsModal!: TemplateRef<unknown>;
+
+  darkMode!: Observable<boolean>;
+
+  readonly groups: readonly GroupedAchievements[] = this.groupAchievements();
+  readonly total = ACHIEVEMENTS.length;
+
+  progress: ReadonlyMap<string, Progress> = new Map();
+  unlocks: AchievementUnlocks = {};
+  totals: readonly LifetimeTotal[] = [];
+
+  private readonly subscriptions = new Subscription();
+
+  ngOnInit(): void {
+    this.darkMode = this.themeService.isDark$;
+
+    this.subscriptions.add(
+      this.achievementService.progress$.subscribe(progress => (this.progress = progress)),
+    );
+    this.subscriptions.add(
+      this.achievementService.unlocked$.subscribe(unlocks => (this.unlocks = unlocks)),
+    );
+
+    // Totals are recomputed whenever anything they read changes.
+    this.subscriptions.add(
+      this.achievementService.progress$.subscribe(() => (this.totals = this.buildTotals())),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  get unlockedCount(): number {
+    return Object.keys(this.unlocks).length;
+  }
+
+  isUnlocked(achievement: Achievement): boolean {
+    return achievement.id in this.unlocks;
+  }
+
+  /**
+   * Hidden achievements stay nameless until earned, so there is something to
+   * discover — and so the three region-locked ones do not read as broken to
+   * someone who never visits those regions.
+   */
+  isConcealed(achievement: Achievement): boolean {
+    return achievement.hidden === true && !this.isUnlocked(achievement);
+  }
+
+  nameKey(achievement: Achievement): string {
+    return achievementNameKey(achievement.id);
+  }
+
+  descriptionKey(achievement: Achievement): string {
+    return achievementDescriptionKey(achievement.id);
+  }
+
+  progressFor(achievement: Achievement): Progress {
+    return this.progress.get(achievement.id) ?? { current: 0, target: 1 };
+  }
+
+  /** Capped at 100: a stored unlock can outlive the threshold that earned it. */
+  percentFor(achievement: Achievement): number {
+    const { current, target } = this.progressFor(achievement);
+    if (target <= 0) {
+      return 100;
+    }
+    return Math.min(100, Math.round((current / target) * 100));
+  }
+
+  groupLabelKey(group: AchievementGroup): string {
+    return `achievementsScreen.group.${group}`;
+  }
+
+  openAchievements(): void {
+    this.modalService.open(this.achievementsModal, { centered: true, size: 'lg', scrollable: true });
+  }
+
+  closeModal(): void {
+    this.modalService.dismissAll();
+  }
+
+  private buildTotals(): LifetimeTotal[] {
+    const caught = this.pokedexService.currentPokedex.caught;
+    const entries = Object.values(caught);
+
+    return [
+      { labelKey: 'achievementsScreen.total.caught', value: entries.length },
+      { labelKey: 'achievementsScreen.total.shiny', value: entries.filter(e => e.shiny).length },
+      { labelKey: 'achievementsScreen.total.badges', value: this.badgeDexService.earned.size },
+      { labelKey: 'achievementsScreen.total.runs', value: this.statsService.get('runs_completed') },
+      { labelKey: 'achievementsScreen.total.spins', value: this.statsService.get('spins_total') },
+    ];
+  }
+
+  private groupAchievements(): GroupedAchievements[] {
+    const order: AchievementGroup[] = [
+      'collection', 'shiny', 'champion', 'rival', 'forms', 'encounters', 'badges', 'grind',
+    ];
+
+    return order.map(group => ({
+      group,
+      achievements: ACHIEVEMENTS.filter(achievement => achievement.group === group),
+    }));
+  }
+}

--- a/src/app/trainer-team/trainer-team.component.html
+++ b/src/app/trainer-team/trainer-team.component.html
@@ -47,6 +47,7 @@
                     <app-storage-pc></app-storage-pc>
                     <app-pokedex></app-pokedex>
                     <app-badge-dex></app-badge-dex>
+                    <app-achievements></app-achievements>
                </div>
           </div>
     </div>

--- a/src/app/trainer-team/trainer-team.component.ts
+++ b/src/app/trainer-team/trainer-team.component.ts
@@ -10,6 +10,7 @@ import { TrainerService } from '../services/trainer-service/trainer.service';
 import { StoragePcComponent } from "./storage-pc/storage-pc.component";
 import { PokedexComponent } from "./pokedex/pokedex.component";
 import { BadgeDexComponent } from "./badge-dex/badge-dex.component";
+import { AchievementsComponent } from "./achievements/achievements.component";
 import {TranslatePipe} from '@ngx-translate/core';
 import { ItemItem } from '../interfaces/item-item';
 import { ImageFallbackDirective } from '../directives/image-fallback.directive';
@@ -20,7 +21,7 @@ import { ImageFallbackDirective } from '../directives/image-fallback.directive';
     ImageFallbackDirective,CommonModule,
     NgbTooltipModule,
     BadgesComponent,
-    StoragePcComponent, TranslatePipe, PokedexComponent, BadgeDexComponent],
+    StoragePcComponent, TranslatePipe, PokedexComponent, BadgeDexComponent, AchievementsComponent],
   templateUrl: './trainer-team.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrls: ['./trainer-team.component.css']

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2832,6 +2832,231 @@
     "title": "Ordensetui",
     "progress": "{{earned}} von {{total}}"
   },
+  "achievementsScreen": {
+    "button": "Erfolge",
+    "title": "Erfolge",
+    "unlocked": "Erfolg freigeschaltet",
+    "hidden": "Noch ein Geheimnis.",
+    "group": {
+      "collection": "Sammlung",
+      "shiny": "Schillernd",
+      "champion": "Champion",
+      "rival": "Rivale",
+      "forms": "Formen",
+      "encounters": "Begegnungen",
+      "badges": "Orden",
+      "grind": "Ausdauer"
+    },
+    "total": {
+      "caught": "Gefangen",
+      "shiny": "Schillernde",
+      "badges": "Orden",
+      "runs": "Siege",
+      "spins": "Drehungen"
+    }
+  },
+  "achievements": {
+    "i_choose_you": {
+      "name": "Ich wähle dich",
+      "description": "Fange dein erstes Pokémon."
+    },
+    "pokedex_lv_1": {
+      "name": "Pokédex Lv 1",
+      "description": "Fange 10 verschiedene Pokémon."
+    },
+    "pokedex_lv_2": {
+      "name": "Pokédex Lv 2",
+      "description": "Fange 50 verschiedene Pokémon."
+    },
+    "pokedex_lv_3": {
+      "name": "Pokédex Lv 3",
+      "description": "Fange 100 verschiedene Pokémon."
+    },
+    "pokedex_lv_4": {
+      "name": "Pokédex Lv 4",
+      "description": "Fange 250 verschiedene Pokémon."
+    },
+    "pokedex_lv_5": {
+      "name": "Pokédex Lv 5",
+      "description": "Fange 500 verschiedene Pokémon."
+    },
+    "gotta_catch_em_all_national": {
+      "name": "Schnapp sie dir... alle?!",
+      "description": "Vervollständige den National-Pokédex."
+    },
+    "gotta_catch_em_all_regional": {
+      "name": "Schnapp sie dir alle!",
+      "description": "Vervollständige den Pokédex einer Region."
+    },
+    "i_choose_you_and_you": {
+      "name": "Ich wähle dich, und dich, und dich...",
+      "description": "Fange alle Starter aus allen neun Regionen."
+    },
+    "paleontologist": {
+      "name": "Paläontologe",
+      "description": "Belebe alle Fossil-Pokémon wieder."
+    },
+    "myth_buster": {
+      "name": "Mythenjäger",
+      "description": "Fange alle legendären Pokémon einer Region."
+    },
+    "oh_shiny": {
+      "name": "Oh, schillernd!",
+      "description": "Finde dein erstes schillerndes Pokémon."
+    },
+    "shiny_hunter_1": {
+      "name": "Schillerjäger I",
+      "description": "Finde 5 schillernde Pokémon."
+    },
+    "shiny_hunter_2": {
+      "name": "Schillerjäger II",
+      "description": "Finde 10 schillernde Pokémon."
+    },
+    "shiny_hunter_3": {
+      "name": "Schillerjäger III",
+      "description": "Finde 25 schillernde Pokémon."
+    },
+    "never_tell_me_the_odds": {
+      "name": "Nenn mir nie die Chancen!",
+      "description": "Finde ein schillerndes legendäres Pokémon."
+    },
+    "champion": {
+      "name": "Champion",
+      "description": "Gewinne deinen ersten Durchlauf."
+    },
+    "regional_champion": {
+      "name": "Regionaler Champion",
+      "description": "Werde Champion in 3 Regionen."
+    },
+    "world_champion": {
+      "name": "Weltmeister",
+      "description": "Werde Champion in allen neun Regionen."
+    },
+    "full_house": {
+      "name": "Volles Haus",
+      "description": "Gewinne mit einem vollen Team aus sechs."
+    },
+    "pokemon_stadium": {
+      "name": "Pokémon Stadium",
+      "description": "Gewinne mit drei Pokémon oder weniger im Team."
+    },
+    "smell_ya_later": {
+      "name": "Man sieht sich!",
+      "description": "Gewinne einen Kampf gegen den Rivalen."
+    },
+    "notch_above": {
+      "name": "Eine Stufe über der Konkurrenz",
+      "description": "Gewinne 5 Kämpfe gegen den Rivalen."
+    },
+    "fruitful_battle": {
+      "name": "Ein fruchtbarer Kampf",
+      "description": "Gewinne 10 Kämpfe gegen den Rivalen."
+    },
+    "evolved_beyond_1": {
+      "name": "Jenseits der Entwicklung I",
+      "description": "Lasse zum ersten Mal ein Pokémon mega-entwickeln."
+    },
+    "evolved_beyond_2": {
+      "name": "Jenseits der Entwicklung II",
+      "description": "Lasse 10 verschiedene Pokémon mega-entwickeln."
+    },
+    "its_a_disguise": {
+      "name": "Es ist ein Kostüm!",
+      "description": "Zerstöre Mimigmas Kostümspuk."
+    },
+    "bond_phenomenon": {
+      "name": "Bund-Phänomen",
+      "description": "Löse die Ash-Quajutsu-Verwandlung aus."
+    },
+    "shapeshifter": {
+      "name": "Gestaltwandler",
+      "description": "Löse eine bleibende Formänderung aus."
+    },
+    "super_rod": {
+      "name": "Superangel",
+      "description": "Fange 10 Pokémon beim Angeln."
+    },
+    "super_nerd": {
+      "name": "Superfreak",
+      "description": "Belebe 10 Fossil-Pokémon wieder."
+    },
+    "prepare_for_trouble": {
+      "name": "Macht euch bereit für Ärger",
+      "description": "Besiege Team Rocket."
+    },
+    "make_it_double": {
+      "name": "Und macht es doppelt",
+      "description": "Besiege Team Rocket, während es dein gestohlenes Pokémon hat."
+    },
+    "mystery_gift": {
+      "name": "Geheimgeschenk",
+      "description": "Lasse ein geheimnisvolles Ei schlüpfen."
+    },
+    "used_the_pokeflute": {
+      "name": "Pokéflöte benutzt",
+      "description": "Fange oder besiege Relaxo."
+    },
+    "five_hundred_steps": {
+      "name": "500 Schritte",
+      "description": "Besuche die Safari-Zone."
+    },
+    "friend_code": {
+      "name": "Freundescode",
+      "description": "Besuche die Freundes-Safari."
+    },
+    "the_great_crater": {
+      "name": "Der Große Krater",
+      "description": "Besuche die Zone Null."
+    },
+    "a_fair_trade": {
+      "name": "Ein Fairer Tausch",
+      "description": "Schließe einen Tausch ab."
+    },
+    "champ_in_the_making": {
+      "name": "He! Ein künftiger Champion!",
+      "description": "Verdiene deinen ersten Orden."
+    },
+    "off_to_victory_road": {
+      "name": "Auf zur Siegesstraße",
+      "description": "Verdiene alle acht Orden einer Region."
+    },
+    "badger_badger_badger": {
+      "name": "Orden, Orden, Orden...",
+      "description": "Verdiene alle Orden aus drei Regionen."
+    },
+    "the_very_best": {
+      "name": "Der Allerbeste, wie keiner zuvor",
+      "description": "Verdiene alle Orden im Spiel."
+    },
+    "youngster": {
+      "name": "Knirps",
+      "description": "Schließe 10 Durchläufe ab."
+    },
+    "bug_catcher": {
+      "name": "Käfersammler",
+      "description": "Schließe 25 Durchläufe ab."
+    },
+    "ace_trainer": {
+      "name": "Ass-Trainer",
+      "description": "Schließe 50 Durchläufe ab."
+    },
+    "veteran": {
+      "name": "Veteran",
+      "description": "Schließe 100 Durchläufe ab."
+    },
+    "wheel_of_fortune": {
+      "name": "Glücksrad",
+      "description": "Drehe das Rad 1.000 Mal."
+    },
+    "whos_that_pokemon": {
+      "name": "Wer ist dieses Pokémon?",
+      "description": "Fange dasselbe Pokémon 50 Mal."
+    },
+    "world_tour": {
+      "name": "Welttournee",
+      "description": "Spiele einen Durchlauf in allen neun Regionen."
+    }
+  },
   "detail": {
     "name": "Name",
     "types": "Typen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2832,6 +2832,231 @@
     "title": "Badge Case",
     "progress": "{{earned}} of {{total}}"
   },
+  "achievementsScreen": {
+    "button": "Achievements",
+    "title": "Achievements",
+    "unlocked": "Achievement unlocked",
+    "hidden": "A secret, for now.",
+    "group": {
+      "collection": "Collection",
+      "shiny": "Shiny",
+      "champion": "Champion",
+      "rival": "Rival",
+      "forms": "Forms",
+      "encounters": "Encounters",
+      "badges": "Badges",
+      "grind": "Dedication"
+    },
+    "total": {
+      "caught": "Caught",
+      "shiny": "Shinies",
+      "badges": "Badges",
+      "runs": "Runs won",
+      "spins": "Spins"
+    }
+  },
+  "achievements": {
+    "i_choose_you": {
+      "name": "I choose you",
+      "description": "Catch your first Pokémon."
+    },
+    "pokedex_lv_1": {
+      "name": "Pokédex Lv 1",
+      "description": "Catch 10 different Pokémon."
+    },
+    "pokedex_lv_2": {
+      "name": "Pokédex Lv 2",
+      "description": "Catch 50 different Pokémon."
+    },
+    "pokedex_lv_3": {
+      "name": "Pokédex Lv 3",
+      "description": "Catch 100 different Pokémon."
+    },
+    "pokedex_lv_4": {
+      "name": "Pokédex Lv 4",
+      "description": "Catch 250 different Pokémon."
+    },
+    "pokedex_lv_5": {
+      "name": "Pokédex Lv 5",
+      "description": "Catch 500 different Pokémon."
+    },
+    "gotta_catch_em_all_national": {
+      "name": "Gotta catch 'em... all?!",
+      "description": "Complete the National Pokédex."
+    },
+    "gotta_catch_em_all_regional": {
+      "name": "Gotta catch 'em all!",
+      "description": "Complete one region's Pokédex."
+    },
+    "i_choose_you_and_you": {
+      "name": "I choose you, and you, and you...",
+      "description": "Catch every starter from all nine regions."
+    },
+    "paleontologist": {
+      "name": "Paleontologist",
+      "description": "Revive every fossil Pokémon."
+    },
+    "myth_buster": {
+      "name": "Myth Buster",
+      "description": "Catch every legendary Pokémon of one region."
+    },
+    "oh_shiny": {
+      "name": "Oh, shiny!",
+      "description": "Find your first shiny Pokémon."
+    },
+    "shiny_hunter_1": {
+      "name": "Shiny Hunter I",
+      "description": "Find 5 shiny Pokémon."
+    },
+    "shiny_hunter_2": {
+      "name": "Shiny Hunter II",
+      "description": "Find 10 shiny Pokémon."
+    },
+    "shiny_hunter_3": {
+      "name": "Shiny Hunter III",
+      "description": "Find 25 shiny Pokémon."
+    },
+    "never_tell_me_the_odds": {
+      "name": "Never tell me the odds!",
+      "description": "Find a shiny legendary Pokémon."
+    },
+    "champion": {
+      "name": "Champion",
+      "description": "Win your first run."
+    },
+    "regional_champion": {
+      "name": "Regional Champion",
+      "description": "Become champion in 3 regions."
+    },
+    "world_champion": {
+      "name": "World Champion",
+      "description": "Become champion in all nine regions."
+    },
+    "full_house": {
+      "name": "Full House",
+      "description": "Win with a full team of six."
+    },
+    "pokemon_stadium": {
+      "name": "Pokémon Stadium",
+      "description": "Win with three Pokémon or fewer on your team."
+    },
+    "smell_ya_later": {
+      "name": "Smell ya later!",
+      "description": "Win a rival battle."
+    },
+    "notch_above": {
+      "name": "A notch above the competition",
+      "description": "Win 5 rival battles."
+    },
+    "fruitful_battle": {
+      "name": "A fruitful battle",
+      "description": "Win 10 rival battles."
+    },
+    "evolved_beyond_1": {
+      "name": "Evolved Beyond I",
+      "description": "Mega evolve a Pokémon for the first time."
+    },
+    "evolved_beyond_2": {
+      "name": "Evolved Beyond II",
+      "description": "Mega evolve 10 different Pokémon."
+    },
+    "its_a_disguise": {
+      "name": "It's a Disguise!",
+      "description": "Break Mimikyu's Disguise."
+    },
+    "bond_phenomenon": {
+      "name": "Bond Phenomenon",
+      "description": "Trigger the Ash-Greninja transformation."
+    },
+    "shapeshifter": {
+      "name": "Shapeshifter",
+      "description": "Trigger a form change that sticks."
+    },
+    "super_rod": {
+      "name": "Super Rod",
+      "description": "Catch 10 Pokémon while fishing."
+    },
+    "super_nerd": {
+      "name": "Super Nerd",
+      "description": "Revive 10 fossil Pokémon."
+    },
+    "prepare_for_trouble": {
+      "name": "Prepare for Trouble",
+      "description": "Defeat Team Rocket."
+    },
+    "make_it_double": {
+      "name": "Make it Double",
+      "description": "Defeat Team Rocket while they hold your stolen Pokémon."
+    },
+    "mystery_gift": {
+      "name": "Mystery Gift",
+      "description": "Hatch a mysterious egg."
+    },
+    "used_the_pokeflute": {
+      "name": "Used the Pokéflute",
+      "description": "Catch or defeat Snorlax."
+    },
+    "five_hundred_steps": {
+      "name": "500 Steps",
+      "description": "Visit the Safari Zone."
+    },
+    "friend_code": {
+      "name": "Friend Code",
+      "description": "Visit the Friend Safari."
+    },
+    "the_great_crater": {
+      "name": "The Great Crater",
+      "description": "Visit Area Zero."
+    },
+    "a_fair_trade": {
+      "name": "A Fair Trade",
+      "description": "Complete a trade."
+    },
+    "champ_in_the_making": {
+      "name": "Yo! Champ in the making!",
+      "description": "Earn your first badge."
+    },
+    "off_to_victory_road": {
+      "name": "Off to the Victory Road",
+      "description": "Earn all eight badges of one region."
+    },
+    "badger_badger_badger": {
+      "name": "Badger, Badger, Badger...",
+      "description": "Earn all the badges of three regions."
+    },
+    "the_very_best": {
+      "name": "The very best, like no one ever was",
+      "description": "Earn every badge in the game."
+    },
+    "youngster": {
+      "name": "Youngster",
+      "description": "Complete 10 runs."
+    },
+    "bug_catcher": {
+      "name": "Bug Catcher",
+      "description": "Complete 25 runs."
+    },
+    "ace_trainer": {
+      "name": "Ace Trainer",
+      "description": "Complete 50 runs."
+    },
+    "veteran": {
+      "name": "Veteran",
+      "description": "Complete 100 runs."
+    },
+    "wheel_of_fortune": {
+      "name": "Wheel of Fortune",
+      "description": "Spin the wheel 1,000 times."
+    },
+    "whos_that_pokemon": {
+      "name": "Who's that Pokémon?",
+      "description": "Catch the same Pokémon 50 times."
+    },
+    "world_tour": {
+      "name": "World Tour",
+      "description": "Play a run in all nine regions."
+    }
+  },
   "detail": {
     "name": "Name",
     "types": "Types",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2832,6 +2832,231 @@
     "title": "Estuche de Medallas",
     "progress": "{{earned}} de {{total}}"
   },
+  "achievementsScreen": {
+    "button": "Logros",
+    "title": "Logros",
+    "unlocked": "Logro desbloqueado",
+    "hidden": "Un secreto, por ahora.",
+    "group": {
+      "collection": "Colección",
+      "shiny": "Shiny",
+      "champion": "Campeón",
+      "rival": "Rival",
+      "forms": "Formas",
+      "encounters": "Encuentros",
+      "badges": "Medallas",
+      "grind": "Dedicación"
+    },
+    "total": {
+      "caught": "Capturados",
+      "shiny": "Shinies",
+      "badges": "Medallas",
+      "runs": "Partidas ganadas",
+      "spins": "Giros"
+    }
+  },
+  "achievements": {
+    "i_choose_you": {
+      "name": "¡Yo te elijo!",
+      "description": "Captura tu primer Pokémon."
+    },
+    "pokedex_lv_1": {
+      "name": "Pokédex Nv 1",
+      "description": "Captura 10 Pokémon diferentes."
+    },
+    "pokedex_lv_2": {
+      "name": "Pokédex Nv 2",
+      "description": "Captura 50 Pokémon diferentes."
+    },
+    "pokedex_lv_3": {
+      "name": "Pokédex Nv 3",
+      "description": "Captura 100 Pokémon diferentes."
+    },
+    "pokedex_lv_4": {
+      "name": "Pokédex Nv 4",
+      "description": "Captura 250 Pokémon diferentes."
+    },
+    "pokedex_lv_5": {
+      "name": "Pokédex Nv 5",
+      "description": "Captura 500 Pokémon diferentes."
+    },
+    "gotta_catch_em_all_national": {
+      "name": "¡Hazte con... todos!",
+      "description": "Completa la Pokédex Nacional."
+    },
+    "gotta_catch_em_all_regional": {
+      "name": "¡Hazte con todos!",
+      "description": "Completa la Pokédex de una región."
+    },
+    "i_choose_you_and_you": {
+      "name": "Te elijo a ti, y a ti, y a ti...",
+      "description": "Captura todos los iniciales de las nueve regiones."
+    },
+    "paleontologist": {
+      "name": "Paleontólogo",
+      "description": "Revive todos los Pokémon fósiles."
+    },
+    "myth_buster": {
+      "name": "Cazador de Mitos",
+      "description": "Captura todos los Pokémon legendarios de una región."
+    },
+    "oh_shiny": {
+      "name": "¡Oh, brillante!",
+      "description": "Encuentra tu primer Pokémon variocolor."
+    },
+    "shiny_hunter_1": {
+      "name": "Cazador de Variocolor I",
+      "description": "Encuentra 5 Pokémon variocolor."
+    },
+    "shiny_hunter_2": {
+      "name": "Cazador de Variocolor II",
+      "description": "Encuentra 10 Pokémon variocolor."
+    },
+    "shiny_hunter_3": {
+      "name": "Cazador de Variocolor III",
+      "description": "Encuentra 25 Pokémon variocolor."
+    },
+    "never_tell_me_the_odds": {
+      "name": "¡No me hables de probabilidades!",
+      "description": "Encuentra un Pokémon legendario variocolor."
+    },
+    "champion": {
+      "name": "Campeón",
+      "description": "Gana tu primera partida."
+    },
+    "regional_champion": {
+      "name": "Campeón Regional",
+      "description": "Conviértete en campeón de 3 regiones."
+    },
+    "world_champion": {
+      "name": "Campeón Mundial",
+      "description": "Conviértete en campeón de las nueve regiones."
+    },
+    "full_house": {
+      "name": "Equipo Completo",
+      "description": "Gana con un equipo completo de seis."
+    },
+    "pokemon_stadium": {
+      "name": "Pokémon Stadium",
+      "description": "Gana con tres Pokémon o menos en el equipo."
+    },
+    "smell_ya_later": {
+      "name": "¡Nos vemos, primo!",
+      "description": "Gana un combate contra el rival."
+    },
+    "notch_above": {
+      "name": "Un escalón por encima",
+      "description": "Gana 5 combates contra el rival."
+    },
+    "fruitful_battle": {
+      "name": "Un combate fructífero",
+      "description": "Gana 10 combates contra el rival."
+    },
+    "evolved_beyond_1": {
+      "name": "Más Allá de la Evolución I",
+      "description": "Megaevoluciona un Pokémon por primera vez."
+    },
+    "evolved_beyond_2": {
+      "name": "Más Allá de la Evolución II",
+      "description": "Megaevoluciona 10 Pokémon diferentes."
+    },
+    "its_a_disguise": {
+      "name": "¡Es un Disfraz!",
+      "description": "Rompe el Disfraz de Mimikyu."
+    },
+    "bond_phenomenon": {
+      "name": "Fenómeno del Vínculo",
+      "description": "Activa la transformación Ash-Greninja."
+    },
+    "shapeshifter": {
+      "name": "Cambiaformas",
+      "description": "Activa un cambio de forma permanente."
+    },
+    "super_rod": {
+      "name": "Supercaña",
+      "description": "Captura 10 Pokémon pescando."
+    },
+    "super_nerd": {
+      "name": "Supernerd",
+      "description": "Revive 10 Pokémon fósiles."
+    },
+    "prepare_for_trouble": {
+      "name": "Prepárate para los Problemas",
+      "description": "Derrota al Team Rocket."
+    },
+    "make_it_double": {
+      "name": "Que sean Dos",
+      "description": "Derrota al Team Rocket mientras tienen tu Pokémon robado."
+    },
+    "mystery_gift": {
+      "name": "Regalo Misterioso",
+      "description": "Incuba un huevo misterioso."
+    },
+    "used_the_pokeflute": {
+      "name": "Usó la Pokéflauta",
+      "description": "Captura o derrota a Snorlax."
+    },
+    "five_hundred_steps": {
+      "name": "500 Pasos",
+      "description": "Visita la Zona Safari."
+    },
+    "friend_code": {
+      "name": "Código de Amigo",
+      "description": "Visita la Zona Safari Amigo."
+    },
+    "the_great_crater": {
+      "name": "El Gran Cráter",
+      "description": "Visita el Área Cero."
+    },
+    "a_fair_trade": {
+      "name": "Un Intercambio Justo",
+      "description": "Completa un intercambio."
+    },
+    "champ_in_the_making": {
+      "name": "¡Eh! ¡Futuro campeón!",
+      "description": "Consigue tu primera medalla."
+    },
+    "off_to_victory_road": {
+      "name": "Rumbo a la Calle Victoria",
+      "description": "Consigue las ocho medallas de una región."
+    },
+    "badger_badger_badger": {
+      "name": "Medalla, Medalla, Medalla...",
+      "description": "Consigue todas las medallas de tres regiones."
+    },
+    "the_very_best": {
+      "name": "El mejor de todos, como nadie más",
+      "description": "Consigue todas las medallas del juego."
+    },
+    "youngster": {
+      "name": "Joven",
+      "description": "Completa 10 partidas."
+    },
+    "bug_catcher": {
+      "name": "Cazabichos",
+      "description": "Completa 25 partidas."
+    },
+    "ace_trainer": {
+      "name": "Entrenador Guay",
+      "description": "Completa 50 partidas."
+    },
+    "veteran": {
+      "name": "Veterano",
+      "description": "Completa 100 partidas."
+    },
+    "wheel_of_fortune": {
+      "name": "Rueda de la Fortuna",
+      "description": "Gira la ruleta 1.000 veces."
+    },
+    "whos_that_pokemon": {
+      "name": "¿Quién es ese Pokémon?",
+      "description": "Captura el mismo Pokémon 50 veces."
+    },
+    "world_tour": {
+      "name": "Gira Mundial",
+      "description": "Juega una partida en las nueve regiones."
+    }
+  },
   "detail": {
     "name": "Nombre",
     "types": "Tipos",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -2832,6 +2832,231 @@
     "title": "Boîte à Badges",
     "progress": "{{earned}} sur {{total}}"
   },
+  "achievementsScreen": {
+    "button": "Succès",
+    "title": "Succès",
+    "unlocked": "Succès débloqué",
+    "hidden": "Un secret, pour l’instant.",
+    "group": {
+      "collection": "Collection",
+      "shiny": "Chromatiques",
+      "champion": "Champion",
+      "rival": "Rival",
+      "forms": "Formes",
+      "encounters": "Rencontres",
+      "badges": "Badges",
+      "grind": "Persévérance"
+    },
+    "total": {
+      "caught": "Capturés",
+      "shiny": "Chromatiques",
+      "badges": "Badges",
+      "runs": "Parties gagnées",
+      "spins": "Tours"
+    }
+  },
+  "achievements": {
+    "i_choose_you": {
+      "name": "Je te choisis",
+      "description": "Capturez votre premier Pokémon."
+    },
+    "pokedex_lv_1": {
+      "name": "Pokédex Niv 1",
+      "description": "Capturez 10 Pokémon différents."
+    },
+    "pokedex_lv_2": {
+      "name": "Pokédex Niv 2",
+      "description": "Capturez 50 Pokémon différents."
+    },
+    "pokedex_lv_3": {
+      "name": "Pokédex Niv 3",
+      "description": "Capturez 100 Pokémon différents."
+    },
+    "pokedex_lv_4": {
+      "name": "Pokédex Niv 4",
+      "description": "Capturez 250 Pokémon différents."
+    },
+    "pokedex_lv_5": {
+      "name": "Pokédex Niv 5",
+      "description": "Capturez 500 Pokémon différents."
+    },
+    "gotta_catch_em_all_national": {
+      "name": "Attrapez-les... tous ?!",
+      "description": "Complétez le Pokédex National."
+    },
+    "gotta_catch_em_all_regional": {
+      "name": "Attrapez-les tous !",
+      "description": "Complétez le Pokédex d'une région."
+    },
+    "i_choose_you_and_you": {
+      "name": "Je te choisis, et toi, et toi...",
+      "description": "Capturez tous les starters des neuf régions."
+    },
+    "paleontologist": {
+      "name": "Paléontologue",
+      "description": "Ressuscitez tous les Pokémon fossiles."
+    },
+    "myth_buster": {
+      "name": "Briseur de Mythes",
+      "description": "Capturez tous les Pokémon légendaires d'une région."
+    },
+    "oh_shiny": {
+      "name": "Oh, chromatique !",
+      "description": "Trouvez votre premier Pokémon chromatique."
+    },
+    "shiny_hunter_1": {
+      "name": "Chasseur de Chromatiques I",
+      "description": "Trouvez 5 Pokémon chromatiques."
+    },
+    "shiny_hunter_2": {
+      "name": "Chasseur de Chromatiques II",
+      "description": "Trouvez 10 Pokémon chromatiques."
+    },
+    "shiny_hunter_3": {
+      "name": "Chasseur de Chromatiques III",
+      "description": "Trouvez 25 Pokémon chromatiques."
+    },
+    "never_tell_me_the_odds": {
+      "name": "Ne me parlez jamais des probabilités !",
+      "description": "Trouvez un Pokémon légendaire chromatique."
+    },
+    "champion": {
+      "name": "Champion",
+      "description": "Gagnez votre première partie."
+    },
+    "regional_champion": {
+      "name": "Champion Régional",
+      "description": "Devenez champion de 3 régions."
+    },
+    "world_champion": {
+      "name": "Champion du Monde",
+      "description": "Devenez champion des neuf régions."
+    },
+    "full_house": {
+      "name": "Équipe Complète",
+      "description": "Gagnez avec une équipe complète de six."
+    },
+    "pokemon_stadium": {
+      "name": "Pokémon Stadium",
+      "description": "Gagnez avec trois Pokémon ou moins dans l'équipe."
+    },
+    "smell_ya_later": {
+      "name": "À plus, minable !",
+      "description": "Gagnez un combat contre le rival."
+    },
+    "notch_above": {
+      "name": "Un cran au-dessus",
+      "description": "Gagnez 5 combats contre le rival."
+    },
+    "fruitful_battle": {
+      "name": "Un combat fructueux",
+      "description": "Gagnez 10 combats contre le rival."
+    },
+    "evolved_beyond_1": {
+      "name": "Au-delà de l'Évolution I",
+      "description": "Méga-évoluez un Pokémon pour la première fois."
+    },
+    "evolved_beyond_2": {
+      "name": "Au-delà de l'Évolution II",
+      "description": "Méga-évoluez 10 Pokémon différents."
+    },
+    "its_a_disguise": {
+      "name": "C'est un Déguisement !",
+      "description": "Brisez le Déguisement de Mimiqui."
+    },
+    "bond_phenomenon": {
+      "name": "Phénomène de Lien",
+      "description": "Déclenchez la transformation Sacha-Amphinobi."
+    },
+    "shapeshifter": {
+      "name": "Métamorphe",
+      "description": "Déclenchez un changement de forme permanent."
+    },
+    "super_rod": {
+      "name": "Super Canne",
+      "description": "Capturez 10 Pokémon à la pêche."
+    },
+    "super_nerd": {
+      "name": "Super Intello",
+      "description": "Ressuscitez 10 Pokémon fossiles."
+    },
+    "prepare_for_trouble": {
+      "name": "Préparez-vous à des Ennuis",
+      "description": "Battez la Team Rocket."
+    },
+    "make_it_double": {
+      "name": "Et Même à Deux",
+      "description": "Battez la Team Rocket alors qu'elle détient votre Pokémon volé."
+    },
+    "mystery_gift": {
+      "name": "Cadeau Mystère",
+      "description": "Faites éclore un œuf mystérieux."
+    },
+    "used_the_pokeflute": {
+      "name": "A utilisé la Pokéflûte",
+      "description": "Capturez ou battez Ronflex."
+    },
+    "five_hundred_steps": {
+      "name": "500 Pas",
+      "description": "Visitez le Parc Safari."
+    },
+    "friend_code": {
+      "name": "Code Ami",
+      "description": "Visitez le Safari des Amis."
+    },
+    "the_great_crater": {
+      "name": "Le Grand Cratère",
+      "description": "Visitez la Zone Zéro."
+    },
+    "a_fair_trade": {
+      "name": "Un Échange Équitable",
+      "description": "Réalisez un échange."
+    },
+    "champ_in_the_making": {
+      "name": "Hé ! Futur champion !",
+      "description": "Obtenez votre premier badge."
+    },
+    "off_to_victory_road": {
+      "name": "En route pour la Route Victoire",
+      "description": "Obtenez les huit badges d'une région."
+    },
+    "badger_badger_badger": {
+      "name": "Badge, Badge, Badge...",
+      "description": "Obtenez tous les badges de trois régions."
+    },
+    "the_very_best": {
+      "name": "Le meilleur dresseur, comme nul autre",
+      "description": "Obtenez tous les badges du jeu."
+    },
+    "youngster": {
+      "name": "Gamin",
+      "description": "Terminez 10 parties."
+    },
+    "bug_catcher": {
+      "name": "Attrape-Insecte",
+      "description": "Terminez 25 parties."
+    },
+    "ace_trainer": {
+      "name": "Topdresseur",
+      "description": "Terminez 50 parties."
+    },
+    "veteran": {
+      "name": "Vétéran",
+      "description": "Terminez 100 parties."
+    },
+    "wheel_of_fortune": {
+      "name": "Roue de la Fortune",
+      "description": "Faites tourner la roue 1 000 fois."
+    },
+    "whos_that_pokemon": {
+      "name": "Qui est ce Pokémon ?",
+      "description": "Capturez le même Pokémon 50 fois."
+    },
+    "world_tour": {
+      "name": "Tour du Monde",
+      "description": "Jouez une partie dans les neuf régions."
+    }
+  },
   "detail": {
     "name": "Nom",
     "types": "Types",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2832,6 +2832,231 @@
     "title": "Custodia Medaglie",
     "progress": "{{earned}} su {{total}}"
   },
+  "achievementsScreen": {
+    "button": "Obiettivi",
+    "title": "Obiettivi",
+    "unlocked": "Obiettivo sbloccato",
+    "hidden": "Un segreto, per ora.",
+    "group": {
+      "collection": "Collezione",
+      "shiny": "Shiny",
+      "champion": "Campione",
+      "rival": "Rivale",
+      "forms": "Forme",
+      "encounters": "Incontri",
+      "badges": "Medaglie",
+      "grind": "Dedizione"
+    },
+    "total": {
+      "caught": "Catturati",
+      "shiny": "Shiny",
+      "badges": "Medaglie",
+      "runs": "Partite vinte",
+      "spins": "Giri"
+    }
+  },
+  "achievements": {
+    "i_choose_you": {
+      "name": "Scelgo te",
+      "description": "Cattura il tuo primo Pokémon."
+    },
+    "pokedex_lv_1": {
+      "name": "Pokédex Lv 1",
+      "description": "Cattura 10 Pokémon diversi."
+    },
+    "pokedex_lv_2": {
+      "name": "Pokédex Lv 2",
+      "description": "Cattura 50 Pokémon diversi."
+    },
+    "pokedex_lv_3": {
+      "name": "Pokédex Lv 3",
+      "description": "Cattura 100 Pokémon diversi."
+    },
+    "pokedex_lv_4": {
+      "name": "Pokédex Lv 4",
+      "description": "Cattura 250 Pokémon diversi."
+    },
+    "pokedex_lv_5": {
+      "name": "Pokédex Lv 5",
+      "description": "Cattura 500 Pokémon diversi."
+    },
+    "gotta_catch_em_all_national": {
+      "name": "Acchiappali... tutti?!",
+      "description": "Completa il Pokédex Nazionale."
+    },
+    "gotta_catch_em_all_regional": {
+      "name": "Acchiappali tutti!",
+      "description": "Completa il Pokédex di una regione."
+    },
+    "i_choose_you_and_you": {
+      "name": "Scelgo te, e te, e te...",
+      "description": "Cattura tutti gli starter delle nove regioni."
+    },
+    "paleontologist": {
+      "name": "Paleontologo",
+      "description": "Rianima tutti i Pokémon fossili."
+    },
+    "myth_buster": {
+      "name": "Cacciatore di Miti",
+      "description": "Cattura tutti i Pokémon leggendari di una regione."
+    },
+    "oh_shiny": {
+      "name": "Oh, shiny!",
+      "description": "Trova il tuo primo Pokémon shiny."
+    },
+    "shiny_hunter_1": {
+      "name": "Cacciatore di Shiny I",
+      "description": "Trova 5 Pokémon shiny."
+    },
+    "shiny_hunter_2": {
+      "name": "Cacciatore di Shiny II",
+      "description": "Trova 10 Pokémon shiny."
+    },
+    "shiny_hunter_3": {
+      "name": "Cacciatore di Shiny III",
+      "description": "Trova 25 Pokémon shiny."
+    },
+    "never_tell_me_the_odds": {
+      "name": "Non dirmi mai le probabilità!",
+      "description": "Trova un Pokémon leggendario shiny."
+    },
+    "champion": {
+      "name": "Campione",
+      "description": "Vinci la tua prima partita."
+    },
+    "regional_champion": {
+      "name": "Campione Regionale",
+      "description": "Diventa campione in 3 regioni."
+    },
+    "world_champion": {
+      "name": "Campione del Mondo",
+      "description": "Diventa campione in tutte e nove le regioni."
+    },
+    "full_house": {
+      "name": "Squadra al Completo",
+      "description": "Vinci con una squadra completa di sei."
+    },
+    "pokemon_stadium": {
+      "name": "Pokémon Stadium",
+      "description": "Vinci con tre Pokémon o meno in squadra."
+    },
+    "smell_ya_later": {
+      "name": "Ci si vede!",
+      "description": "Vinci una lotta contro il rivale."
+    },
+    "notch_above": {
+      "name": "Un gradino sopra gli altri",
+      "description": "Vinci 5 lotte contro il rivale."
+    },
+    "fruitful_battle": {
+      "name": "Una lotta fruttuosa",
+      "description": "Vinci 10 lotte contro il rivale."
+    },
+    "evolved_beyond_1": {
+      "name": "Oltre l'Evoluzione I",
+      "description": "Fai megaevolvere un Pokémon per la prima volta."
+    },
+    "evolved_beyond_2": {
+      "name": "Oltre l'Evoluzione II",
+      "description": "Fai megaevolvere 10 Pokémon diversi."
+    },
+    "its_a_disguise": {
+      "name": "È un Costume!",
+      "description": "Rompi il Costume di Mimikyu."
+    },
+    "bond_phenomenon": {
+      "name": "Fenomeno del Legame",
+      "description": "Attiva la trasformazione Ash-Greninja."
+    },
+    "shapeshifter": {
+      "name": "Mutaforma",
+      "description": "Attiva un cambio di forma permanente."
+    },
+    "super_rod": {
+      "name": "Supercanna",
+      "description": "Cattura 10 Pokémon pescando."
+    },
+    "super_nerd": {
+      "name": "Super Nerd",
+      "description": "Rianima 10 Pokémon fossili."
+    },
+    "prepare_for_trouble": {
+      "name": "Preparati alla Lotta",
+      "description": "Sconfiggi il Team Rocket."
+    },
+    "make_it_double": {
+      "name": "Fanne il Doppio",
+      "description": "Sconfiggi il Team Rocket mentre ha il tuo Pokémon rubato."
+    },
+    "mystery_gift": {
+      "name": "Dono Segreto",
+      "description": "Fai schiudere un uovo misterioso."
+    },
+    "used_the_pokeflute": {
+      "name": "Ha usato il Pokéflauto",
+      "description": "Cattura o sconfiggi Snorlax."
+    },
+    "five_hundred_steps": {
+      "name": "500 Passi",
+      "description": "Visita la Zona Safari."
+    },
+    "friend_code": {
+      "name": "Codice Amico",
+      "description": "Visita il Safari degli Amici."
+    },
+    "the_great_crater": {
+      "name": "Il Grande Cratere",
+      "description": "Visita l'Area Zero."
+    },
+    "a_fair_trade": {
+      "name": "Uno Scambio Equo",
+      "description": "Completa uno scambio."
+    },
+    "champ_in_the_making": {
+      "name": "Ehi! Futuro campione!",
+      "description": "Ottieni la tua prima medaglia."
+    },
+    "off_to_victory_road": {
+      "name": "Verso la Via Vittoria",
+      "description": "Ottieni tutte e otto le medaglie di una regione."
+    },
+    "badger_badger_badger": {
+      "name": "Medaglia, Medaglia, Medaglia...",
+      "description": "Ottieni tutte le medaglie di tre regioni."
+    },
+    "the_very_best": {
+      "name": "Il migliore, come nessuno mai",
+      "description": "Ottieni tutte le medaglie del gioco."
+    },
+    "youngster": {
+      "name": "Giovane",
+      "description": "Completa 10 partite."
+    },
+    "bug_catcher": {
+      "name": "Acchiappabug",
+      "description": "Completa 25 partite."
+    },
+    "ace_trainer": {
+      "name": "Fantallenatore",
+      "description": "Completa 50 partite."
+    },
+    "veteran": {
+      "name": "Veterano",
+      "description": "Completa 100 partite."
+    },
+    "wheel_of_fortune": {
+      "name": "Ruota della Fortuna",
+      "description": "Gira la ruota 1.000 volte."
+    },
+    "whos_that_pokemon": {
+      "name": "Chi è quel Pokémon?",
+      "description": "Cattura lo stesso Pokémon 50 volte."
+    },
+    "world_tour": {
+      "name": "Tour Mondiale",
+      "description": "Gioca una partita in tutte e nove le regioni."
+    }
+  },
   "detail": {
     "name": "Nome",
     "types": "Tipi",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2832,6 +2832,231 @@
     "title": "Estojo de Insígnias",
     "progress": "{{earned}} de {{total}}"
   },
+  "achievementsScreen": {
+    "button": "Conquistas",
+    "title": "Conquistas",
+    "unlocked": "Conquista desbloqueada",
+    "hidden": "Um segredo, por enquanto.",
+    "group": {
+      "collection": "Coleção",
+      "shiny": "Shiny",
+      "champion": "Campeão",
+      "rival": "Rival",
+      "forms": "Formas",
+      "encounters": "Encontros",
+      "badges": "Insígnias",
+      "grind": "Dedicação"
+    },
+    "total": {
+      "caught": "Capturados",
+      "shiny": "Shinies",
+      "badges": "Insígnias",
+      "runs": "Runs vencidas",
+      "spins": "Giros"
+    }
+  },
+  "achievements": {
+    "i_choose_you": {
+      "name": "Eu escolho você",
+      "description": "Capture seu primeiro Pokémon."
+    },
+    "pokedex_lv_1": {
+      "name": "Pokédex Nv 1",
+      "description": "Capture 10 Pokémon diferentes."
+    },
+    "pokedex_lv_2": {
+      "name": "Pokédex Nv 2",
+      "description": "Capture 50 Pokémon diferentes."
+    },
+    "pokedex_lv_3": {
+      "name": "Pokédex Nv 3",
+      "description": "Capture 100 Pokémon diferentes."
+    },
+    "pokedex_lv_4": {
+      "name": "Pokédex Nv 4",
+      "description": "Capture 250 Pokémon diferentes."
+    },
+    "pokedex_lv_5": {
+      "name": "Pokédex Nv 5",
+      "description": "Capture 500 Pokémon diferentes."
+    },
+    "gotta_catch_em_all_national": {
+      "name": "Temos que pegar... todos?!",
+      "description": "Complete a Pokédex Nacional."
+    },
+    "gotta_catch_em_all_regional": {
+      "name": "Temos que pegar todos!",
+      "description": "Complete a Pokédex de uma região."
+    },
+    "i_choose_you_and_you": {
+      "name": "Eu escolho você, e você, e você...",
+      "description": "Capture todos os iniciais das nove regiões."
+    },
+    "paleontologist": {
+      "name": "Paleontólogo",
+      "description": "Reviva todos os Pokémon fósseis."
+    },
+    "myth_buster": {
+      "name": "Caçador de Mitos",
+      "description": "Capture todos os Pokémon lendários de uma região."
+    },
+    "oh_shiny": {
+      "name": "Ooh, shiny!",
+      "description": "Encontre seu primeiro Pokémon shiny."
+    },
+    "shiny_hunter_1": {
+      "name": "Caçador de Shiny I",
+      "description": "Encontre 5 Pokémon shiny."
+    },
+    "shiny_hunter_2": {
+      "name": "Caçador de Shiny II",
+      "description": "Encontre 10 Pokémon shiny."
+    },
+    "shiny_hunter_3": {
+      "name": "Caçador de Shiny III",
+      "description": "Encontre 25 Pokémon shiny."
+    },
+    "never_tell_me_the_odds": {
+      "name": "Nunca me fale as chances!",
+      "description": "Encontre um Pokémon lendário shiny."
+    },
+    "champion": {
+      "name": "Campeão",
+      "description": "Vença sua primeira run."
+    },
+    "regional_champion": {
+      "name": "Campeão Regional",
+      "description": "Torne-se campeão em 3 regiões."
+    },
+    "world_champion": {
+      "name": "Campeão Mundial",
+      "description": "Torne-se campeão nas nove regiões."
+    },
+    "full_house": {
+      "name": "Casa Cheia",
+      "description": "Vença com um time completo de seis."
+    },
+    "pokemon_stadium": {
+      "name": "Pokémon Stadium",
+      "description": "Vença com três Pokémon ou menos no time."
+    },
+    "smell_ya_later": {
+      "name": "Até mais, otário!",
+      "description": "Vença uma batalha contra o rival."
+    },
+    "notch_above": {
+      "name": "Um degrau acima da concorrência",
+      "description": "Vença 5 batalhas contra o rival."
+    },
+    "fruitful_battle": {
+      "name": "Uma batalha frutífera",
+      "description": "Vença 10 batalhas contra o rival."
+    },
+    "evolved_beyond_1": {
+      "name": "Além da Evolução I",
+      "description": "Mega evolua um Pokémon pela primeira vez."
+    },
+    "evolved_beyond_2": {
+      "name": "Além da Evolução II",
+      "description": "Mega evolua 10 Pokémon diferentes."
+    },
+    "its_a_disguise": {
+      "name": "É um Disfarce!",
+      "description": "Quebre o Disfarce de Mimikyu."
+    },
+    "bond_phenomenon": {
+      "name": "Fenômeno do Vínculo",
+      "description": "Ative a transformação Ash-Greninja."
+    },
+    "shapeshifter": {
+      "name": "Metamorfo",
+      "description": "Ative uma mudança de forma permanente."
+    },
+    "super_rod": {
+      "name": "Super Vara",
+      "description": "Capture 10 Pokémon pescando."
+    },
+    "super_nerd": {
+      "name": "Super Nerd",
+      "description": "Reviva 10 Pokémon fósseis."
+    },
+    "prepare_for_trouble": {
+      "name": "Preparem-se para Encrenca",
+      "description": "Derrote a Equipe Rocket."
+    },
+    "make_it_double": {
+      "name": "E façam em Dobro",
+      "description": "Derrote a Equipe Rocket enquanto eles têm seu Pokémon roubado."
+    },
+    "mystery_gift": {
+      "name": "Presente Misterioso",
+      "description": "Choque um ovo misterioso."
+    },
+    "used_the_pokeflute": {
+      "name": "Usou a Pokéflauta",
+      "description": "Capture ou derrote Snorlax."
+    },
+    "five_hundred_steps": {
+      "name": "500 Passos",
+      "description": "Visite a Zona Safári."
+    },
+    "friend_code": {
+      "name": "Código de Amigo",
+      "description": "Visite o Safári dos Amigos."
+    },
+    "the_great_crater": {
+      "name": "A Grande Cratera",
+      "description": "Visite a Área Zero."
+    },
+    "a_fair_trade": {
+      "name": "Uma Troca Justa",
+      "description": "Complete uma troca."
+    },
+    "champ_in_the_making": {
+      "name": "E aí! Futuro campeão!",
+      "description": "Conquiste sua primeira insígnia."
+    },
+    "off_to_victory_road": {
+      "name": "Rumo à Estrada da Vitória",
+      "description": "Conquiste as oito insígnias de uma região."
+    },
+    "badger_badger_badger": {
+      "name": "Insígnia, Insígnia, Insígnia...",
+      "description": "Conquiste todas as insígnias de três regiões."
+    },
+    "the_very_best": {
+      "name": "O melhor de todos, como ninguém jamais foi",
+      "description": "Conquiste todas as insígnias do jogo."
+    },
+    "youngster": {
+      "name": "Jovem",
+      "description": "Complete 10 runs."
+    },
+    "bug_catcher": {
+      "name": "Caçador de Insetos",
+      "description": "Complete 25 runs."
+    },
+    "ace_trainer": {
+      "name": "Treinador Ás",
+      "description": "Complete 50 runs."
+    },
+    "veteran": {
+      "name": "Veterano",
+      "description": "Complete 100 runs."
+    },
+    "wheel_of_fortune": {
+      "name": "Roda da Fortuna",
+      "description": "Gire a roleta 1.000 vezes."
+    },
+    "whos_that_pokemon": {
+      "name": "Quem é esse Pokémon?",
+      "description": "Capture o mesmo Pokémon 50 vezes."
+    },
+    "world_tour": {
+      "name": "Turnê Mundial",
+      "description": "Jogue uma run nas nove regiões."
+    }
+  },
   "detail": {
     "name": "Nome",
     "types": "Tipos",


### PR DESCRIPTION
Closes #52 **and #55**. Together because a screen that renders raw translation keys isn't a screen — and ngx-translate's parity rule means the strings can't land one locale at a time.

465/465 tests, build green, bundle 1.53 MB, i18n parity at **2351 keys**.

## Verified in a browser, not just in specs

This is the failure `CLAUDE.md` warns about — every test passes while the app shows raw keys. So I opened it:

**English** — `Achievements 11 / 50`, totals reading `140 caught / 7 shinies / 4 badges / 12 runs / 430 spins`, ticks on earned rows, progress bars on the rest.
**Portuguese** — *"Eu escolho você"*, *"Temos que pegar... todos?!"*, *"Caçador de Mitos"*, group headers as `COLEÇÃO`.

Hidden achievements read **"??? / A secret, for now."** with no progress numbers. Seeded values line up: Super Rod 3/10, A fruitful battle 6/10, Myth Buster 0/5.

One number looked wrong and wasn't: I seeded 3 shinies and the total read **7**. That's correct — shiny propagates along evolution chains (Vulpix→Ninetales, Geodude→Graveler→Golem, Rhyhorn→Rhydon).

## The toast is deliberately not a modal

It fires **mid-run**, usually right after a catch or a gym win when result modals are already queued — a modal here would stomp one, which is exactly what `ModalQueueService` exists to prevent.

The layer is **`pointer-events: none`**, so a banner can never swallow a click meant for the wheel. Only the card is clickable, to dismiss. Several unlocks **queue** rather than stack — shorter when more are waiting, shorter again under `lessExplanations`. It sits **outside the router outlet** so it survives navigation, and reuses the existing `item-found` sound rather than adding an asset to a bundle already at 1.53 against 1.55 MB.

## The screen

Progress bars come from the **same `progress()` function that decides unlocking**, so a bar and a tick can't disagree. The bar is capped at 100% because a stored unlock outlives the threshold that earned it, and an uncapped one overflows its track — there's a test.

## Two things worth your eye

- **The trainer panel now has four buttons and the row is crowding** — the last label truncates at desktop width. Not addressed here; tell me if you want it reworked into a dropdown or icons-only.
- **The references were localised by sense, not by looking up each official dub line.** "Smell ya later!", "Who's that Pokémon?" and the trainer-class names (Youngster, Bug Catcher, Ace Trainer) especially deserve a native eye — **the Portuguese most of all**, since that's the one you'll notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)