### PR TITLE
Account UI: sign in, sign up, sign out, delete

### DIFF
--- a/src/app/services/auth-service/auth.service.spec.ts
+++ b/src/app/services/auth-service/auth.service.spec.ts
@@ -1,0 +1,109 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { AuthService } from './auth.service';
+import { environment } from '../../../environments/environment';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let http: HttpTestingController;
+
+  const base = `${environment.apiBaseUrl}/v1`;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(AuthService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('starts signed out', () => {
+    expect(service.isSignedIn).toBeFalse();
+  });
+
+  // The session cookie is HttpOnly by design, so every call has to carry
+  // credentials explicitly or the browser sends nothing.
+  it('sends credentials with every request', () => {
+    service.refresh().subscribe();
+    const request = http.expectOne(`${base}/auth/me`);
+
+    expect(request.request.withCredentials)
+      .withContext('without this the HttpOnly session cookie is never sent')
+      .toBeTrue();
+
+    request.flush(null, { status: 401, statusText: 'Unauthorized' });
+  });
+
+  it('remembers who signed in', () => {
+    service.login('ash@pallet.town', 'pikachu-i-choose-you').subscribe();
+    http.expectOne(`${base}/auth/login`).flush({ id: 'abc', email: 'ash@pallet.town' });
+
+    expect(service.currentUser?.email).toBe('ash@pallet.town');
+  });
+
+  it('forgets on sign out', () => {
+    service.login('ash@pallet.town', 'pikachu-i-choose-you').subscribe();
+    http.expectOne(`${base}/auth/login`).flush({ id: 'abc', email: 'ash@pallet.town' });
+
+    service.logout().subscribe();
+    http.expectOne(`${base}/auth/logout`).flush(null);
+
+    expect(service.isSignedIn).toBeFalse();
+  });
+
+  // A player with no account must never be shown an error for a question they
+  // did not ask. Any failure simply means signed out.
+  it('treats an unreachable API as signed out, not as an error', () => {
+    let errored = false;
+    let result: unknown = 'unset';
+
+    service.refresh().subscribe({
+      next: user => (result = user),
+      error: () => (errored = true),
+    });
+
+    http.expectOne(`${base}/auth/me`).error(new ProgressEvent('network error'));
+
+    expect(errored).withContext('the game must keep working with the API down').toBeFalse();
+    expect(result).toBeNull();
+    expect(service.isSignedIn).toBeFalse();
+  });
+
+  it('reports the check as done even when it failed', () => {
+    let checked = false;
+    service.checked$.subscribe(value => (checked = value));
+
+    service.refresh().subscribe();
+    http.expectOne(`${base}/auth/me`).flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(checked).toBeTrue();
+  });
+
+  describe('error messages', () => {
+    // Signup and login answer "wrong password" and "no such account"
+    // identically on purpose. Rewording here would undo that on the client.
+    it('shows exactly what the server said', () => {
+      const response = new HttpErrorResponse({
+        status: 401,
+        error: { error: { code: 'unauthorized', message: 'That email and password do not match an account.' } },
+      });
+
+      expect(AuthService.messageFor(response, 'fallback'))
+        .toBe('That email and password do not match an account.');
+    });
+
+    it('falls back when there is no message to show', () => {
+      expect(AuthService.messageFor(new HttpErrorResponse({ status: 0 }), 'fallback')).toBe('fallback');
+      expect(AuthService.messageFor(new Error('boom'), 'fallback')).toBe('fallback');
+    });
+  });
+});

--- a/src/app/services/auth-service/auth.service.ts
+++ b/src/app/services/auth-service/auth.service.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { BehaviorSubject, Observable, catchError, map, of, tap, throwError } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface AuthUser {
+  readonly id: string;
+  readonly email: string;
+}
+
+/** The shape every error response from the API takes. */
+interface ApiErrorEnvelope {
+  error?: { code?: string; message?: string; request_id?: string };
+}
+
+/**
+ * Accounts, and whether there is one.
+ *
+ * **The game works with no account, forever.** Nothing here may gate play: a
+ * failing request means "not signed in", never an error the player has to
+ * dismiss before continuing.
+ *
+ * The session lives in an `HttpOnly` cookie, which JavaScript cannot read by
+ * design — that is the whole reason the game moved to a sibling hostname. So
+ * "am I signed in" is answered by asking the server, not by inspecting storage.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly base = `${environment.apiBaseUrl}/v1`;
+
+  private userSubject$ = new BehaviorSubject<AuthUser | null>(null);
+  private checkedSubject$ = new BehaviorSubject<boolean>(false);
+
+  constructor(private http: HttpClient) {}
+
+  get user$(): Observable<AuthUser | null> {
+    return this.userSubject$.asObservable();
+  }
+
+  get currentUser(): AuthUser | null {
+    return this.userSubject$.getValue();
+  }
+
+  get isSignedIn(): boolean {
+    return this.currentUser !== null;
+  }
+
+  /** Whether the initial "who am I" has completed, however it went. */
+  get checked$(): Observable<boolean> {
+    return this.checkedSubject$.asObservable();
+  }
+
+  /**
+   * Asks the server who the caller is.
+   *
+   * Any failure — no session, API down, no network — resolves to "signed out".
+   * A player with no account must never see an error for a question they did
+   * not ask.
+   */
+  refresh(): Observable<AuthUser | null> {
+    return this.http.get<AuthUser>(`${this.base}/auth/me`, { withCredentials: true }).pipe(
+      catchError(() => of(null)),
+      tap(user => {
+        this.userSubject$.next(user);
+        this.checkedSubject$.next(true);
+      }),
+    );
+  }
+
+  signup(email: string, password: string): Observable<AuthUser> {
+    return this.post<AuthUser>('/auth/signup', { email, password });
+  }
+
+  login(email: string, password: string): Observable<AuthUser> {
+    return this.post<AuthUser>('/auth/login', { email, password });
+  }
+
+  /** Ends this session. */
+  logout(): Observable<void> {
+    return this.http
+      .post<void>(`${this.base}/auth/logout`, {}, { withCredentials: true })
+      .pipe(tap(() => this.userSubject$.next(null)));
+  }
+
+  /**
+   * Ends every session for the account.
+   *
+   * With no password reset, this is the only recourse a player has if they
+   * think someone else is signed in as them.
+   */
+  logoutEverywhere(): Observable<void> {
+    return this.http
+      .post<void>(`${this.base}/auth/logout-all`, {}, { withCredentials: true })
+      .pipe(tap(() => this.userSubject$.next(null)));
+  }
+
+  deleteAccount(password: string): Observable<void> {
+    return this.http
+      .request<void>('DELETE', `${this.base}/account`, { body: { password }, withCredentials: true })
+      .pipe(tap(() => this.userSubject$.next(null)));
+  }
+
+  /**
+   * The message to show a player for a failed request.
+   *
+   * Returns exactly what the API said. The signup and login endpoints answer
+   * "wrong password" and "no such account" identically **on purpose**, and a
+   * client that guesses a more specific message undoes that on the front end.
+   */
+  static messageFor(error: unknown, fallback: string): string {
+    if (error instanceof HttpErrorResponse) {
+      const body = error.error as ApiErrorEnvelope | null;
+      const message = body?.error?.message;
+      if (typeof message === 'string' && message.length > 0) {
+        return message;
+      }
+    }
+    return fallback;
+  }
+
+  private post<T>(path: string, body: unknown): Observable<T> {
+    return this.http.post<T>(`${this.base}${path}`, body, { withCredentials: true }).pipe(
+      tap(user => this.userSubject$.next(user as AuthUser)),
+      map(user => user),
+      catchError((error: unknown) => throwError(() => error)),
+    );
+  }
+}

--- a/src/app/settings/account/account.component.css
+++ b/src/app/settings/account/account.component.css
@@ -1,0 +1,63 @@
+.account {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-width: 26rem;
+}
+
+.account-heading {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.account-note,
+.account-hint {
+  font-size: 0.72rem;
+  opacity: 0.75;
+  margin: 0;
+}
+
+/* Consequences a player needs to read before acting, not after. */
+.account-warning {
+  font-size: 0.72rem;
+  margin: 0;
+  padding: 0.35rem 0.5rem;
+  border-left: 3px solid #f5c518;
+  background: rgba(245, 197, 24, 0.12);
+}
+
+.account-error {
+  font-size: 0.75rem;
+  margin: 0;
+  padding: 0.35rem 0.5rem;
+  border-left: 3px solid #dc3545;
+  background: rgba(220, 53, 69, 0.12);
+}
+
+.account-tabs,
+.account-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.account-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.account-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.account-signed-in {
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.account-delete {
+  align-self: flex-start;
+  margin-top: 0.35rem;
+}

--- a/src/app/settings/account/account.component.html
+++ b/src/app/settings/account/account.component.html
@@ -1,0 +1,111 @@
+<section class="account">
+  <h3 class="account-heading">{{ 'account.title' | translate }}</h3>
+
+  @if (!checked) {
+    <p class="account-note">{{ 'account.checking' | translate }}</p>
+  } @else if (user) {
+
+    <p class="account-signed-in">
+      {{ 'account.signedInAs' | translate }} <strong>{{ user.email }}</strong>
+    </p>
+
+    @if (hasUnsyncedProgress) {
+      <p class="account-warning">{{ 'account.unsyncedWarning' | translate }}</p>
+    }
+
+    <div class="account-actions">
+      <button type="button" class="btn btn-outline-secondary btn-sm"
+              [disabled]="busy" (click)="signOut()">
+        {{ 'account.signOut' | translate }}
+      </button>
+      <button type="button" class="btn btn-outline-secondary btn-sm"
+              [disabled]="busy" (click)="signOutEverywhere()">
+        {{ 'account.signOutEverywhere' | translate }}
+      </button>
+    </div>
+
+    <p class="account-note">{{ 'account.signOutExplains' | translate }}</p>
+
+    @if (!confirmingDelete) {
+      <button type="button" class="btn btn-outline-danger btn-sm account-delete"
+              [disabled]="busy" (click)="confirmingDelete = true">
+        {{ 'account.delete' | translate }}
+      </button>
+    } @else {
+      <div class="account-form">
+        <p class="account-warning">{{ 'account.deleteWarning' | translate }}</p>
+        <label class="account-label" for="delete-password">{{ 'account.password' | translate }}</label>
+        <input id="delete-password" class="form-control form-control-sm"
+               type="password" autocomplete="current-password"
+               [value]="deletePassword" (input)="deletePassword = $any($event.target).value">
+        <div class="account-actions">
+          <button type="button" class="btn btn-danger btn-sm"
+                  [disabled]="busy || !deletePassword" (click)="deleteAccount()">
+            {{ 'account.deleteConfirm' | translate }}
+          </button>
+          <button type="button" class="btn btn-outline-secondary btn-sm"
+                  [disabled]="busy" (click)="confirmingDelete = false">
+            {{ 'account.cancel' | translate }}
+          </button>
+        </div>
+      </div>
+    }
+
+  } @else {
+
+    <p class="account-note">{{ 'account.optional' | translate }}</p>
+
+    <div class="account-tabs">
+      <button type="button" class="btn btn-sm"
+              [class.btn-primary]="mode === 'signin'"
+              [class.btn-outline-secondary]="mode !== 'signin'"
+              (click)="setMode('signin')">
+        {{ 'account.signIn' | translate }}
+      </button>
+      <button type="button" class="btn btn-sm"
+              [class.btn-primary]="mode === 'signup'"
+              [class.btn-outline-secondary]="mode !== 'signup'"
+              (click)="setMode('signup')">
+        {{ 'account.createAccount' | translate }}
+      </button>
+    </div>
+
+    <div class="account-form">
+      <label class="account-label" for="account-email">{{ 'account.email' | translate }}</label>
+      <input id="account-email" class="form-control form-control-sm"
+             type="email" autocomplete="email"
+             [class.is-invalid]="touched && !emailValid"
+             [value]="email" (input)="email = $any($event.target).value">
+
+      <label class="account-label" for="account-password">{{ 'account.password' | translate }}</label>
+      <input id="account-password" class="form-control form-control-sm"
+             type="password"
+             [attr.autocomplete]="mode === 'signup' ? 'new-password' : 'current-password'"
+             [class.is-invalid]="touched && !passwordValid"
+             [value]="password" (input)="password = $any($event.target).value"
+             (keyup.enter)="submit()">
+      <small class="account-hint">
+        {{ 'account.passwordHint' | translate: { min: minPasswordLength } }}
+      </small>
+
+      @if (mode === 'signup') {
+        <!-- Stated at the point of signup, not buried. There is no SMTP, so a
+             forgotten password is an unrecoverable account, and someone could
+             lose a 900-Pokémon Pokédex to it. -->
+        <p class="account-warning">{{ 'account.noResetWarning' | translate }}</p>
+      }
+
+      <button type="button" class="btn btn-primary btn-sm" [disabled]="busy" (click)="submit()">
+        @if (mode === 'signup') {
+          {{ 'account.createAccount' | translate }}
+        } @else {
+          {{ 'account.signIn' | translate }}
+        }
+      </button>
+    </div>
+  }
+
+  @if (error) {
+    <p class="account-error" role="alert">{{ error }}</p>
+  }
+</section>

--- a/src/app/settings/account/account.component.spec.ts
+++ b/src/app/settings/account/account.component.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+
+import { AccountComponent } from './account.component';
+import { environment } from '../../../environments/environment';
+
+describe('AccountComponent', () => {
+  let fixture: ComponentFixture<AccountComponent>;
+  let component: AccountComponent;
+  let http: HttpTestingController;
+
+  const base = `${environment.apiBaseUrl}/v1`;
+
+  /** The "who am I" the component asks on load; answered signed-out by default. */
+  const answerWhoAmI = (user: unknown = null) => {
+    const request = http.expectOne(`${base}/auth/me`);
+    if (user) {
+      request.flush(user);
+    } else {
+      request.flush(null, { status: 401, statusText: 'Unauthorized' });
+    }
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+
+    await TestBed.configureTestingModule({
+      imports: [AccountComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideTranslateService()],
+    }).compileComponents();
+
+    http = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(AccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterAll(() => localStorage.clear());
+
+  it('should be created', () => {
+    answerWhoAmI();
+    expect(component).toBeTruthy();
+  });
+
+  it('shows the signed-out state when there is no session', () => {
+    answerWhoAmI();
+
+    expect(component.user).toBeNull();
+    expect(component.checked).toBeTrue();
+  });
+
+  describe('validation, which mirrors the backend', () => {
+    beforeEach(() => answerWhoAmI());
+
+    it('rejects a malformed email', () => {
+      component.email = 'not-an-email';
+      expect(component.emailValid).toBeFalse();
+
+      component.email = 'ash@pallet.town';
+      expect(component.emailValid).toBeTrue();
+    });
+
+    it('requires twelve characters, as the server does', () => {
+      component.password = 'short';
+      expect(component.passwordValid).toBeFalse();
+
+      component.password = 'a'.repeat(12);
+      expect(component.passwordValid).toBeTrue();
+    });
+
+    it('does not submit an invalid form', () => {
+      component.email = 'nope';
+      component.password = 'short';
+
+      component.submit();
+
+      http.expectNone(`${base}/auth/login`);
+      expect(component.touched).withContext('and it should say why').toBeTrue();
+    });
+  });
+
+  it('signs in', () => {
+    answerWhoAmI();
+
+    component.email = 'ash@pallet.town';
+    component.password = 'pikachu-i-choose-you';
+    component.submit();
+
+    http.expectOne(`${base}/auth/login`).flush({ id: 'abc', email: 'ash@pallet.town' });
+    fixture.detectChanges();
+
+    expect(component.user?.email).toBe('ash@pallet.town');
+    expect(component.password).withContext('the password must not linger in memory').toBe('');
+  });
+
+  it('creates an account when in signup mode', () => {
+    answerWhoAmI();
+
+    component.setMode('signup');
+    component.email = 'new@pallet.town';
+    component.password = 'a-long-enough-password';
+    component.submit();
+
+    http.expectOne(`${base}/auth/signup`).flush({ id: 'abc', email: 'new@pallet.town' });
+  });
+
+  // Rewording here would undo the server's deliberate refusal to say which of
+  // the two things was wrong.
+  it('shows the server\'s own message on failure', () => {
+    answerWhoAmI();
+
+    component.email = 'ash@pallet.town';
+    component.password = 'pikachu-i-choose-you';
+    component.submit();
+
+    http.expectOne(`${base}/auth/login`).flush(
+      { error: { code: 'unauthorized', message: 'That email and password do not match an account.' } },
+      { status: 401, statusText: 'Unauthorized' },
+    );
+    fixture.detectChanges();
+
+    expect(component.error).toBe('That email and password do not match an account.');
+    expect(component.busy).toBeFalse();
+  });
+
+  it('needs a password before it will delete anything', () => {
+    answerWhoAmI({ id: 'abc', email: 'ash@pallet.town' });
+
+    component.confirmingDelete = true;
+    component.deletePassword = '';
+    component.deleteAccount();
+
+    http.expectNone(`${base}/account`);
+  });
+
+  it('deletes the account when confirmed', () => {
+    answerWhoAmI({ id: 'abc', email: 'ash@pallet.town' });
+
+    component.confirmingDelete = true;
+    component.deletePassword = 'pikachu-i-choose-you';
+    component.deleteAccount();
+
+    const request = http.expectOne(`${base}/account`);
+    expect(request.request.method).toBe('DELETE');
+    request.flush(null);
+    fixture.detectChanges();
+
+    expect(component.user).toBeNull();
+    expect(component.confirmingDelete).toBeFalse();
+  });
+});

--- a/src/app/settings/account/account.component.ts
+++ b/src/app/settings/account/account.component.ts
@@ -1,0 +1,158 @@
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Observable, Subscription } from 'rxjs';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+
+import { AuthService, AuthUser } from '../../services/auth-service/auth.service';
+import { SyncStateService } from '../../services/sync-state-service/sync-state.service';
+
+/** Matches the backend, which rejects anything shorter. */
+const MIN_PASSWORD_LENGTH = 12;
+
+/**
+ * Permissive on purpose, like the server's own check: this rejects nonsense
+ * without pretending to know which addresses can receive mail. Nothing here
+ * sends any.
+ */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type Mode = 'signin' | 'signup';
+
+/**
+ * Account management, in Settings rather than in the game.
+ *
+ * **An account is optional and always will be.** Nothing here gates play,
+ * nothing nags, and a signed-out player's experience is exactly what it was
+ * before accounts existed. This screen is the only place the subject comes up.
+ */
+@Component({
+  selector: 'app-account',
+  imports: [CommonModule, TranslatePipe],
+  templateUrl: './account.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  styleUrl: './account.component.css',
+})
+export class AccountComponent implements OnInit, OnDestroy {
+
+  constructor(
+    private authService: AuthService,
+    private syncState: SyncStateService,
+    private translate: TranslateService,
+  ) {}
+
+  readonly minPasswordLength = MIN_PASSWORD_LENGTH;
+
+  mode: Mode = 'signin';
+  user: AuthUser | null = null;
+  checked = false;
+  busy = false;
+  error = '';
+  confirmingDelete = false;
+
+  // Two text fields and a password confirmation. A forms module for this would
+  // be 4.5 kB of framework to validate an email and count characters — enough
+  // to breach the bundle budget on its own.
+  email = '';
+  password = '';
+  deletePassword = '';
+  touched = false;
+
+  private readonly subscriptions = new Subscription();
+
+  ngOnInit(): void {
+    this.subscriptions.add(this.authService.user$.subscribe(user => (this.user = user)));
+    this.subscriptions.add(this.authService.checked$.subscribe(checked => (this.checked = checked)));
+
+    // Asked here rather than at app start: a player who never opens Settings
+    // never causes a request, and the answer is only needed on this screen
+    // until the sync client lands.
+    this.subscriptions.add(this.authService.refresh().subscribe());
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  get hasUnsyncedProgress(): boolean {
+    return !this.syncState.isSynced;
+  }
+
+  setMode(mode: Mode): void {
+    this.mode = mode;
+    this.error = '';
+    this.touched = false;
+  }
+
+  get emailValid(): boolean {
+    return EMAIL_PATTERN.test(this.email.trim());
+  }
+
+  get passwordValid(): boolean {
+    return this.password.length >= MIN_PASSWORD_LENGTH;
+  }
+
+  get canSubmit(): boolean {
+    return this.emailValid && this.passwordValid && !this.busy;
+  }
+
+  submit(): void {
+    this.touched = true;
+
+    if (!this.canSubmit) {
+      return;
+    }
+
+    const email = this.email.trim();
+    const request = this.mode === 'signup'
+      ? this.authService.signup(email, this.password)
+      : this.authService.login(email, this.password);
+
+    this.run(request, 'account.error.generic', () => {
+      this.email = '';
+      this.password = '';
+      this.touched = false;
+    });
+  }
+
+  signOut(): void {
+    this.run(this.authService.logout(), 'account.error.generic');
+  }
+
+  signOutEverywhere(): void {
+    this.run(this.authService.logoutEverywhere(), 'account.error.generic');
+  }
+
+  deleteAccount(): void {
+    if (this.deletePassword.length === 0 || this.busy) {
+      return;
+    }
+
+    this.run(this.authService.deleteAccount(this.deletePassword), 'account.error.generic', () => {
+      this.deletePassword = '';
+      this.confirmingDelete = false;
+    });
+  }
+
+  /**
+   * Runs a request, showing whatever the server said on failure.
+   *
+   * Deliberately not translated and not reworded: signup and login answer
+   * "wrong password" and "no account" identically on purpose, and inventing a
+   * more specific message here would undo that.
+   */
+  private run<T>(request: Observable<T>, fallbackKey: string, onSuccess?: () => void): void {
+    this.busy = true;
+    this.error = '';
+
+    request.subscribe({
+      next: () => {
+        this.busy = false;
+        onSuccess?.();
+      },
+      error: (failure: unknown) => {
+        this.busy = false;
+        this.error = AuthService.messageFor(failure, this.translate.instant(fallbackKey) as string);
+      },
+    });
+  }
+}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -121,6 +121,10 @@
                     <div class="col-12">
                         <app-language-selector></app-language-selector>
                     </div>
+                    <div class="col-12">
+                        <hr>
+                        <app-account></app-account>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -7,6 +7,7 @@ import { NgIconsModule } from '@ng-icons/core';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 import { SettingsService, GameSettings } from '../services/settings-service/settings.service';
+import { AccountComponent } from './account/account.component';
 
 @Component({
   selector: 'app-settings',
@@ -16,7 +17,8 @@ import { SettingsService, GameSettings } from '../services/settings-service/sett
     TranslatePipe,
     MainGameButtonComponent,
     NgIconsModule,
-    CommonModule
+    CommonModule,
+    AccountComponent
 ],
   templateUrl: './settings.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3057,6 +3057,29 @@
       "description": "Spiele einen Durchlauf in allen neun Regionen."
     }
   },
+  "account": {
+    "title": "Konto",
+    "checking": "Wird geprüft…",
+    "optional": "Ein Konto ist optional. Das Spiel funktioniert auch ohne — die Anmeldung hält nur deine Sammlung auf allen Geräten gleich.",
+    "signIn": "Anmelden",
+    "createAccount": "Konto erstellen",
+    "email": "E-Mail",
+    "password": "Passwort",
+    "passwordHint": "Mindestens {{min}} Zeichen.",
+    "noResetWarning": "Es gibt keine Passwortwiederherstellung. Wenn du dieses Passwort vergisst, sind das Konto und alles darin endgültig verloren. Schreib es auf.",
+    "signedInAs": "Angemeldet als",
+    "signOut": "Abmelden",
+    "signOutEverywhere": "Überall abmelden",
+    "signOutExplains": "Beim Abmelden wird deine Sammlung von diesem Gerät entfernt. Sie bleibt in deinem Konto und kehrt bei der nächsten Anmeldung zurück.",
+    "unsyncedWarning": "Ein Teil des Fortschritts hat dein Konto noch nicht erreicht. Wenn du dich jetzt abmeldest, geht er verloren.",
+    "delete": "Konto löschen",
+    "deleteConfirm": "Endgültig löschen",
+    "cancel": "Abbrechen",
+    "deleteWarning": "Damit werden dein Konto und alle Inhalte endgültig gelöscht. Gib zur Bestätigung dein Passwort ein.",
+    "error": {
+      "generic": "Das hat nicht geklappt. Bitte versuche es erneut."
+    }
+  },
   "detail": {
     "name": "Name",
     "types": "Typen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3057,6 +3057,29 @@
       "description": "Play a run in all nine regions."
     }
   },
+  "account": {
+    "title": "Account",
+    "checking": "Checking…",
+    "optional": "An account is optional. The game works without one — signing in only keeps your collection in step across devices.",
+    "signIn": "Sign in",
+    "createAccount": "Create account",
+    "email": "Email",
+    "password": "Password",
+    "passwordHint": "At least {{min}} characters.",
+    "noResetWarning": "There is no password reset. If you forget this password, the account and everything in it are gone for good. Write it down.",
+    "signedInAs": "Signed in as",
+    "signOut": "Sign out",
+    "signOutEverywhere": "Sign out everywhere",
+    "signOutExplains": "Signing out removes your collection from this device. It stays on your account, and comes back when you sign in.",
+    "unsyncedWarning": "Some progress has not reached your account yet. Sign out and it will be lost.",
+    "delete": "Delete account",
+    "deleteConfirm": "Delete permanently",
+    "cancel": "Cancel",
+    "deleteWarning": "This deletes your account and everything in it, permanently. Enter your password to confirm.",
+    "error": {
+      "generic": "That did not work. Please try again."
+    }
+  },
   "detail": {
     "name": "Name",
     "types": "Types",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3057,6 +3057,29 @@
       "description": "Juega una partida en las nueve regiones."
     }
   },
+  "account": {
+    "title": "Cuenta",
+    "checking": "Comprobando…",
+    "optional": "La cuenta es opcional. El juego funciona sin ella — iniciar sesión solo mantiene tu colección sincronizada entre dispositivos.",
+    "signIn": "Iniciar sesión",
+    "createAccount": "Crear cuenta",
+    "email": "Correo",
+    "password": "Contraseña",
+    "passwordHint": "Al menos {{min}} caracteres.",
+    "noResetWarning": "No hay recuperación de contraseña. Si la olvidas, la cuenta y todo lo que contiene se pierden para siempre. Apúntala.",
+    "signedInAs": "Sesión iniciada como",
+    "signOut": "Cerrar sesión",
+    "signOutEverywhere": "Cerrar sesión en todos los dispositivos",
+    "signOutExplains": "Cerrar sesión elimina tu colección de este dispositivo. Permanece en tu cuenta y vuelve cuando inicies sesión.",
+    "unsyncedWarning": "Parte del progreso aún no ha llegado a tu cuenta. Si cierras sesión ahora, se perderá.",
+    "delete": "Eliminar cuenta",
+    "deleteConfirm": "Eliminar permanentemente",
+    "cancel": "Cancelar",
+    "deleteWarning": "Esto elimina tu cuenta y todo su contenido, de forma permanente. Escribe tu contraseña para confirmar.",
+    "error": {
+      "generic": "No ha funcionado. Inténtalo de nuevo."
+    }
+  },
   "detail": {
     "name": "Nombre",
     "types": "Tipos",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -3057,6 +3057,29 @@
       "description": "Jouez une partie dans les neuf régions."
     }
   },
+  "account": {
+    "title": "Compte",
+    "checking": "Vérification…",
+    "optional": "Le compte est facultatif. Le jeu fonctionne sans — se connecter sert uniquement à synchroniser votre collection entre appareils.",
+    "signIn": "Se connecter",
+    "createAccount": "Créer un compte",
+    "email": "E-mail",
+    "password": "Mot de passe",
+    "passwordHint": "Au moins {{min}} caractères.",
+    "noResetWarning": "Il n'y a aucune réinitialisation de mot de passe. Si vous l'oubliez, le compte et tout son contenu sont perdus définitivement. Notez-le.",
+    "signedInAs": "Connecté en tant que",
+    "signOut": "Se déconnecter",
+    "signOutEverywhere": "Se déconnecter partout",
+    "signOutExplains": "La déconnexion retire votre collection de cet appareil. Elle reste sur votre compte et revient à la reconnexion.",
+    "unsyncedWarning": "Une partie de la progression n'a pas encore atteint votre compte. Si vous vous déconnectez maintenant, elle sera perdue.",
+    "delete": "Supprimer le compte",
+    "deleteConfirm": "Supprimer définitivement",
+    "cancel": "Annuler",
+    "deleteWarning": "Ceci supprime votre compte et tout son contenu, définitivement. Saisissez votre mot de passe pour confirmer.",
+    "error": {
+      "generic": "Cela n'a pas fonctionné. Veuillez réessayer."
+    }
+  },
   "detail": {
     "name": "Nom",
     "types": "Types",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3057,6 +3057,29 @@
       "description": "Gioca una partita in tutte e nove le regioni."
     }
   },
+  "account": {
+    "title": "Account",
+    "checking": "Verifica in corso…",
+    "optional": "L'account è facoltativo. Il gioco funziona anche senza — accedere serve solo a mantenere la collezione allineata tra dispositivi.",
+    "signIn": "Accedi",
+    "createAccount": "Crea account",
+    "email": "Email",
+    "password": "Password",
+    "passwordHint": "Almeno {{min}} caratteri.",
+    "noResetWarning": "Non esiste il recupero della password. Se la dimentichi, l'account e tutto il suo contenuto sono persi per sempre. Annotala.",
+    "signedInAs": "Connesso come",
+    "signOut": "Esci",
+    "signOutEverywhere": "Esci da tutti i dispositivi",
+    "signOutExplains": "Uscendo, la tua collezione viene rimossa da questo dispositivo. Resta nel tuo account e torna quando accedi di nuovo.",
+    "unsyncedWarning": "Parte dei progressi non ha ancora raggiunto il tuo account. Se esci ora, andranno persi.",
+    "delete": "Elimina account",
+    "deleteConfirm": "Elimina definitivamente",
+    "cancel": "Annulla",
+    "deleteWarning": "Questo elimina il tuo account e tutto il suo contenuto, definitivamente. Inserisci la password per confermare.",
+    "error": {
+      "generic": "Non ha funzionato. Riprova."
+    }
+  },
   "detail": {
     "name": "Nome",
     "types": "Tipi",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3057,6 +3057,29 @@
       "description": "Jogue uma run nas nove regiões."
     }
   },
+  "account": {
+    "title": "Conta",
+    "checking": "Verificando…",
+    "optional": "A conta é opcional. O jogo funciona sem ela — entrar apenas mantém sua coleção sincronizada entre dispositivos.",
+    "signIn": "Entrar",
+    "createAccount": "Criar conta",
+    "email": "E-mail",
+    "password": "Senha",
+    "passwordHint": "Pelo menos {{min}} caracteres.",
+    "noResetWarning": "Não existe recuperação de senha. Se você esquecer esta senha, a conta e tudo nela são perdidos para sempre. Anote-a.",
+    "signedInAs": "Conectado como",
+    "signOut": "Sair",
+    "signOutEverywhere": "Sair de todos os dispositivos",
+    "signOutExplains": "Sair remove sua coleção deste dispositivo. Ela continua na sua conta e volta quando você entrar novamente.",
+    "unsyncedWarning": "Parte do progresso ainda não chegou à sua conta. Se você sair agora, será perdido.",
+    "delete": "Excluir conta",
+    "deleteConfirm": "Excluir permanentemente",
+    "cancel": "Cancelar",
+    "deleteWarning": "Isso exclui sua conta e tudo nela, permanentemente. Digite sua senha para confirmar.",
+    "error": {
+      "generic": "Não funcionou. Tente novamente."
+    }
+  },
   "detail": {
     "name": "Nome",
     "types": "Tipos",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,7 @@
 export const environment = {
   production: true,
   googleAnalyticsId: 'G-40CS5XD7G9',
+  // A sibling host under zeroxm.com.br, which is what lets the session cookie
+  // be shared. See the backend's docs/sync.md.
+  apiBaseUrl: 'https://pokemon-roulette-api.zeroxm.com.br',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,7 @@
 export const environment = {
   production: false,
   googleAnalyticsId: '',
+  // Local backend. `docker compose up` in pokemon-roulette-backend serves this,
+  // and its CORS allowlist includes http://localhost:4200.
+  apiBaseUrl: 'http://localhost:8080',
 };


### PR DESCRIPTION
Closes #56. 484/484 tests, build green, bundle **1.54 MB**, i18n parity at 2370 keys.

It lives in **Settings**, not the game, because the constraint that outranks everything here is that **an account is optional and always will be**. Nothing gates play, nothing nags, and a signed-out player's experience is exactly what it was before accounts existed.

## Verified against a real backend

Not just specs. I ran the backend locally, created an account from the dev server, and watched the UI switch:

> **Signed in as ash@pallet.town**
> ⚠ Some progress has not reached your account yet. Sign out and it will be lost.
> Signing out removes your collection from this device. It stays on your account, and comes back when you sign in.

Then confirmed the row and its session in Postgres, and tore the local stack down.

**That's also how I found a real bug** — in the *backend* repo. A compose service's `environment:` block **replaces** the merged anchor's rather than merging into it, so the dev API had no `PRA_CORS_ORIGINS` at all. Local development of anything talking to the API was impossible, and it presents as a backend bug rather than a compose one. Fixed in [backend #36](https://github.com/zeroxm/pokemon-roulette-backend/pull/36).

## Decisions

**Error text is whatever the server said, verbatim.** Signup and login answer "wrong password" and "no such account" identically *on purpose*; inventing a more specific message on the client would undo that. There's a test.

**Any failure of "who am I" means signed out, not an error.** API down, no network, no session — all the same. A player with no account must never see a failure for a question they didn't ask.

**The no-password-reset warning is at the point of signup**, not buried. There's no SMTP, so a forgotten password is an unrecoverable account — someone could lose a 900-Pokémon Pokédex to it.

## No forms module

I reached for `ReactiveFormsModule` first and it pushed the bundle to **1.55 MB, breaching the budget by 4.58 kB** — 4.5 kB of framework to validate an email and count characters. Two fields don't need it. Removing it is both smaller *and* simpler, which is the direction this codebase has been going all along.

The budget doing its job here is worth noting: it caught weight I hadn't earned rather than being raised to accommodate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)