### PR TITLE
Sync client: conflict-free merge across devices

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,8 @@ import { RouterOutlet } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { environment } from '../environments/environment';
 import { ThemeService } from './services/theme-service/theme.service';
+import { AuthService } from './services/auth-service/auth.service';
+import { SyncService } from './services/sync-service/sync.service';
 import { AchievementToastComponent } from './achievements/achievement-toast/achievement-toast.component';
 
 const SUPPORTED_LANGUAGES = ['en', 'es', 'fr', 'de', 'it', 'pt'] as const;
@@ -25,6 +27,8 @@ export class AppComponent {
     // Eagerly instantiate ThemeService so the stored theme is applied on startup,
     // before any settings panel is opened.
     _theme: ThemeService,
+    authService: AuthService,
+    syncService: SyncService,
   ) {
     // The stored value is interpolated into the loader's fetch URL
     // (./assets/i18n/${lang}.json), so it must be checked against the supported
@@ -37,6 +41,11 @@ export class AppComponent {
       ? stored
       : DEFAULT_LANGUAGE;
     this.translate.use(savedLanguage);
+
+    // One request on startup to find out whether there is an account, then the
+    // sync client picks it up. A signed-out player never causes another.
+    syncService.start();
+    authService.refresh().subscribe();
 
     if (environment.production && environment.googleAnalyticsId) {
       this.loadGoogleAnalytics(environment.googleAnalyticsId);

--- a/src/app/services/achievement-service/achievement.service.ts
+++ b/src/app/services/achievement-service/achievement.service.ts
@@ -156,6 +156,28 @@ export class AchievementService {
     };
   }
 
+  /**
+   * Replaces the unlock record with merged state.
+   *
+   * **The sync client must call this before adopting the collections.** Every
+   * collection emission re-runs `evaluate`, so adopting another device's
+   * Pokédex first would announce fifty achievements at once for things earned
+   * months ago on that device — the exact toast storm the stored record exists
+   * to prevent.
+   */
+  adopt(unlocks: AchievementUnlocks): void {
+    const known = new Set(ACHIEVEMENTS.map(achievement => achievement.id));
+    const filtered: Record<string, string> = {};
+    for (const [id, at] of Object.entries(unlocks)) {
+      if (known.has(id)) {
+        filtered[id] = at;
+      }
+    }
+
+    this.save(filtered);
+    this.unlockedSubject$.next(filtered);
+  }
+
   private save(unlocks: AchievementUnlocks): void {
     try {
       localStorage.setItem(this.STORAGE_KEY, JSON.stringify(unlocks));

--- a/src/app/services/badge-dex-service/badge-dex.service.ts
+++ b/src/app/services/badge-dex-service/badge-dex.service.ts
@@ -49,6 +49,13 @@ export class BadgeDexService {
     this.earnedSubject$.next(next);
   }
 
+  /** Replaces the trophy case with merged state. See PokedexService.adopt. */
+  adopt(badgeIds: readonly string[]): void {
+    const next = new Set(badgeIds.filter(id => ALL_BADGE_IDS.has(id)));
+    this.save(next);
+    this.earnedSubject$.next(next);
+  }
+
   private save(badges: ReadonlySet<string>): void {
     try {
       localStorage.setItem(this.STORAGE_KEY, JSON.stringify([...badges].sort()));

--- a/src/app/services/pokedex-service/pokedex.service.ts
+++ b/src/app/services/pokedex-service/pokedex.service.ts
@@ -135,6 +135,19 @@ export class PokedexService {
     this.updatePokedex({ caught: updatedCaught });
   }
 
+  /**
+   * Replaces the Pokédex with state the sync client has already merged.
+   *
+   * Does **not** mark anything dirty: what is being written is, by
+   * construction, a superset of both what was local and what the server holds.
+   * Marking it dirty would make the very act of syncing schedule another sync.
+   */
+  adopt(caught: Record<string, PokedexEntry>): void {
+    const data: PokedexData = { caught };
+    this.savePokedexToStorage(data);
+    this.pokedexSubject$.next(data);
+  }
+
   private updatePokedex(data: PokedexData): void {
     this.savePokedexToStorage(data);
     this.syncState.markDirty();

--- a/src/app/services/settings-service/settings.service.ts
+++ b/src/app/services/settings-service/settings.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, distinctUntilChanged, Observable } from 'rxjs';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
 
 export interface GameSettings {
   muteAudio: boolean;
@@ -25,7 +26,7 @@ export class SettingsService {
 
   private settingsSubject$: BehaviorSubject<GameSettings>;
 
-  constructor() {
+  constructor(private syncState: SyncStateService) {
     this.settingsSubject$ = new BehaviorSubject(this.getInitialSettings());
   }
 
@@ -74,8 +75,22 @@ export class SettingsService {
     this.updateSettings(this.defaultSettings);
   }
 
+  /**
+   * Replaces settings with merged state. See PokedexService.adopt.
+   *
+   * Settings are the one last-write-wins collection, so unlike the others this
+   * can overwrite a local value — with the server's, which by definition
+   * reached it later.
+   */
+  adopt(settings: Partial<GameSettings>): void {
+    const validated = this.validate(settings);
+    this.saveSettingsToStorage(validated);
+    this.settingsSubject$.next(validated);
+  }
+
   private updateSettings(newSettings: GameSettings): void {
     this.saveSettingsToStorage(newSettings);
+    this.syncState.markDirty();
     this.settingsSubject$.next(newSettings);
   }
 
@@ -90,7 +105,10 @@ export class SettingsService {
    * validation is decided, which a loop would have silently skipped.
    */
   private getInitialSettings(): GameSettings {
-    const stored = this.getSettingsFromStorage() ?? {};
+    return this.validate(this.getSettingsFromStorage() ?? {});
+  }
+
+  private validate(stored: Partial<GameSettings>): GameSettings {
     const defaults = this.defaultSettings;
     const bool = (value: unknown, fallback: boolean): boolean =>
       typeof value === 'boolean' ? value : fallback;

--- a/src/app/services/stats-service/stats.service.ts
+++ b/src/app/services/stats-service/stats.service.ts
@@ -99,6 +99,19 @@ export class StatsService {
     this.update(next as PlayerStats);
   }
 
+  /** Replaces the counters with merged state. See PokedexService.adopt. */
+  adopt(counters: Record<string, number>): void {
+    const stats: Record<string, number> = {};
+    for (const [key, value] of Object.entries(counters)) {
+      if (isCounterKey(key) && Number.isFinite(value) && value > 0) {
+        stats[key] = Math.floor(value);
+      }
+    }
+
+    this.saveToStorage(stats as PlayerStats);
+    this.statsSubject$.next(stats as PlayerStats);
+  }
+
   private update(stats: PlayerStats): void {
     const pruned = this.withoutZeros(stats);
     this.saveToStorage(pruned);

--- a/src/app/services/sync-service/sync-snapshot.spec.ts
+++ b/src/app/services/sync-service/sync-snapshot.spec.ts
@@ -1,0 +1,159 @@
+import { EMPTY_SNAPSHOT, SyncSnapshot, mergeSnapshots, parseSyncSnapshot } from './sync-snapshot';
+import { GameSettings } from '../settings-service/settings.service';
+
+function snapshot(partial: Partial<SyncSnapshot>): SyncSnapshot {
+  return { ...EMPTY_SNAPSHOT, ...partial };
+}
+
+const settings: GameSettings = {
+  muteAudio: true,
+  skipShinyRolls: false,
+  skipMegaEvolutionAnimation: false,
+  lessExplanations: false,
+  defaultGender: 'always-choose',
+};
+
+describe('mergeSnapshots', () => {
+
+  it('unions two disjoint Pokédexes', () => {
+    const desktop = snapshot({ pokedex: { '6': { won: true, shiny: false, mega: false, count: 2 } } });
+    const phone = snapshot({ pokedex: { '25': { won: false, shiny: true, mega: false, count: 1 } } });
+
+    const merged = mergeSnapshots(desktop, phone);
+
+    expect(Object.keys(merged.pokedex).sort()).toEqual(['25', '6']);
+    expect(merged.pokedex['6'].count).toBe(2);
+    expect(merged.pokedex['25'].shiny).toBeTrue();
+  });
+
+  it('never lets a false clear a true', () => {
+    const withShiny = snapshot({ pokedex: { '6': { won: true, shiny: true, mega: true, count: 5 } } });
+    const withoutShiny = snapshot({ pokedex: { '6': { won: false, shiny: false, mega: false, count: 1 } } });
+
+    for (const merged of [mergeSnapshots(withShiny, withoutShiny), mergeSnapshots(withoutShiny, withShiny)]) {
+      expect(merged.pokedex['6']).toEqual({ won: true, shiny: true, mega: true, count: 5 });
+    }
+  });
+
+  it('keeps the earliest unlock time for an achievement both devices have', () => {
+    const early = snapshot({ achievements: { oh_shiny: '2026-01-01T00:00:00Z' } });
+    const late = snapshot({ achievements: { oh_shiny: '2026-06-01T00:00:00Z' } });
+
+    expect(mergeSnapshots(early, late).achievements['oh_shiny']).toBe('2026-01-01T00:00:00Z');
+    expect(mergeSnapshots(late, early).achievements['oh_shiny']).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('takes the higher counter rather than summing', () => {
+    // The documented trade: two devices offline at once under-count. Pinned
+    // here so nobody "fixes" it into a rule that can double-count on a retry.
+    const a = snapshot({ counters: { spins_total: 100 } });
+    const b = snapshot({ counters: { spins_total: 120 } });
+
+    expect(mergeSnapshots(a, b).counters['spins_total']).toBe(120);
+  });
+
+  it('lets the newer side win on settings, and only on settings', () => {
+    const older = snapshot({ badges: ['boulder'], settings });
+    const newer = snapshot({ badges: ['cascade'], settings: { ...settings, muteAudio: false } });
+
+    const merged = mergeSnapshots(older, newer);
+
+    expect(merged.settings?.muteAudio).toBeFalse();
+    expect(merged.badges).toEqual(['boulder', 'cascade']);
+  });
+
+  it('keeps the other side settings when the newer side has none', () => {
+    expect(mergeSnapshots(snapshot({ settings }), snapshot({})).settings).toEqual(settings);
+  });
+
+  it('converges when two devices go offline, both play, and both come back', () => {
+    // The hardest case and the one that matters: neither device saw the other,
+    // and the order they reconnect in must not change the outcome.
+    const shared = snapshot({
+      pokedex: { '1': { won: true, shiny: false, mega: false, count: 1 } },
+      badges: ['boulder'],
+      counters: { spins_total: 10 },
+      achievements: { first_steps: '2026-01-01T00:00:00Z' },
+    });
+
+    const desktop = snapshot({
+      pokedex: {
+        '1': { won: true, shiny: true, mega: false, count: 3 },
+        '4': { won: true, shiny: false, mega: false, count: 1 },
+      },
+      badges: ['boulder', 'cascade'],
+      counters: { spins_total: 40, runs_completed: 1 },
+      achievements: { first_steps: '2026-01-01T00:00:00Z', oh_shiny: '2026-02-01T00:00:00Z' },
+    });
+
+    const phone = snapshot({
+      pokedex: {
+        '1': { won: true, shiny: false, mega: true, count: 8 },
+        '7': { won: false, shiny: false, mega: false, count: 2 },
+      },
+      badges: ['boulder', 'thunder'],
+      counters: { spins_total: 25, eggs_hatched: 4 },
+      achievements: { first_steps: '2025-12-01T00:00:00Z' },
+    });
+
+    const desktopFirst = mergeSnapshots(mergeSnapshots(shared, desktop), phone);
+    const phoneFirst = mergeSnapshots(mergeSnapshots(shared, phone), desktop);
+
+    expect(desktopFirst).toEqual(phoneFirst);
+    expect(desktopFirst.pokedex['1']).toEqual({ won: true, shiny: true, mega: true, count: 8 });
+    expect(desktopFirst.badges).toEqual(['boulder', 'cascade', 'thunder']);
+    expect(desktopFirst.counters).toEqual({ spins_total: 40, runs_completed: 1, eggs_hatched: 4 });
+    expect(desktopFirst.achievements['first_steps']).toBe('2025-12-01T00:00:00Z');
+  });
+
+  it('is a no-op when the same state is merged twice', () => {
+    // What makes a blind retry safe, and why there is no idempotency key.
+    const once = mergeSnapshots(EMPTY_SNAPSHOT, snapshot({ counters: { spins_total: 11 } }));
+    expect(mergeSnapshots(once, once)).toEqual(once);
+  });
+});
+
+describe('parseSyncSnapshot', () => {
+
+  it('reads a well-formed response', () => {
+    const parsed = parseSyncSnapshot({
+      schema_version: 1,
+      pokedex: { '6': { won: true, shiny: true, mega: false, count: 11 } },
+      badges: ['boulder'],
+      achievements: { oh_shiny: '2026-03-01T12:00:00Z' },
+      counters: { runs_completed: 12 },
+      settings: { muteAudio: true },
+    });
+
+    expect(parsed.pokedex['6']).toEqual({ won: true, shiny: true, mega: false, count: 11 });
+    expect(parsed.badges).toEqual(['boulder']);
+    expect(parsed.counters).toEqual({ runs_completed: 12 });
+    expect(parsed.settings).toEqual({ muteAudio: true } as unknown as GameSettings);
+  });
+
+  it('floors a Pokédex count at one', () => {
+    const parsed = parseSyncSnapshot({ pokedex: { '6': { won: true, count: 0 } } });
+    expect(parsed.pokedex['6'].count).toBe(1);
+  });
+
+  it('survives a response from a build it has never met', () => {
+    // The API deploys on its own schedule, so an unknown field is routine.
+    // Refusing to parse would strand a collection on the server.
+    const parsed = parseSyncSnapshot({
+      schema_version: 99,
+      pokedex: { '6': { won: true, count: 3, sparkles: 'yes' } },
+      trophies: ['???'],
+      counters: { runs_completed: 4, counter_from_the_future: 9 },
+    });
+
+    expect(parsed.pokedex['6'].count).toBe(3);
+    expect(parsed.counters).toEqual({ runs_completed: 4, counter_from_the_future: 9 });
+  });
+
+  it('reads garbage as empty rather than throwing', () => {
+    for (const body of [null, 'nope', 42, [], { pokedex: 'no', badges: {}, counters: [] }]) {
+      expect(() => parseSyncSnapshot(body)).not.toThrow();
+      expect(parseSyncSnapshot(body).badges).toEqual([]);
+    }
+  });
+});

--- a/src/app/services/sync-service/sync-snapshot.ts
+++ b/src/app/services/sync-service/sync-snapshot.ts
@@ -1,0 +1,211 @@
+import { GameSettings } from '../settings-service/settings.service';
+
+/**
+ * A player's whole collection, in the shape the API speaks.
+ *
+ * Pure data and pure functions, with no Angular in sight, because the merge
+ * rules *are* the product here: the HTTP around them is a thin shell, and a
+ * wrong rule loses a Pokédex in a way nobody notices until someone reports
+ * their shinies vanished. The contract is `docs/sync.md` in the backend repo.
+ *
+ * Kept separate from the sync client so the one-time migration off the old
+ * origin (#59) can merge a handed-over snapshot with exactly these rules,
+ * rather than with a second implementation that drifts.
+ */
+
+/** No `sprite`: the URL is derived from the id, on both sides. */
+export interface SyncPokedexEntry {
+  won: boolean;
+  shiny: boolean;
+  mega: boolean;
+  count: number;
+}
+
+export interface SyncSnapshot {
+  pokedex: Record<string, SyncPokedexEntry>;
+  badges: string[];
+  /** Achievement id to ISO 8601 unlock time. */
+  achievements: Record<string, string>;
+  counters: Record<string, number>;
+  /**
+   * `null` for a player who has never changed one, and `Partial` because the
+   * server stores settings as an opaque blob it does not validate — a payload
+   * written by another build may be missing a field this one expects.
+   * `SettingsService.adopt` fills the gaps from defaults.
+   */
+  settings: Partial<GameSettings> | null;
+}
+
+export const EMPTY_SNAPSHOT: SyncSnapshot = {
+  pokedex: {},
+  badges: [],
+  achievements: {},
+  counters: {},
+  settings: null,
+};
+
+/**
+ * Unions two snapshots. **No rule here may ever decrease a value** — that is
+ * the single property that makes syncing safe without locks or vector clocks.
+ *
+ * `incoming` is the *newer* side, and the only thing that means is which
+ * settings win; every other collection is grow-only and therefore order
+ * independent. `merge(a, b)` and `merge(b, a)` agree on everything except
+ * settings, and there is a test pinning that.
+ */
+export function mergeSnapshots(base: SyncSnapshot, incoming: SyncSnapshot): SyncSnapshot {
+  return {
+    pokedex: mergePokedex(base.pokedex, incoming.pokedex),
+    badges: [...new Set([...base.badges, ...incoming.badges])].sort(),
+    achievements: mergeAchievements(base.achievements, incoming.achievements),
+    counters: mergeCounters(base.counters, incoming.counters),
+    // Last-write-wins, and the only rule here that can lose a change. Tolerable
+    // only because a setting is trivial to re-toggle; nothing expensive to lose
+    // may ever be stored this way.
+    settings: incoming.settings ?? base.settings,
+  };
+}
+
+/**
+ * Field-wise OR, count by max.
+ *
+ * A client sending `false` never clears anything: a phone that has not seen
+ * your desktop's shiny Charizard sends `shiny: false`, and the shiny survives.
+ */
+function mergePokedex(
+  base: Record<string, SyncPokedexEntry>,
+  incoming: Record<string, SyncPokedexEntry>,
+): Record<string, SyncPokedexEntry> {
+  const merged: Record<string, SyncPokedexEntry> = { ...base };
+
+  for (const [id, entry] of Object.entries(incoming)) {
+    const existing = merged[id];
+    merged[id] = existing
+      ? {
+          won: existing.won || entry.won,
+          shiny: existing.shiny || entry.shiny,
+          mega: existing.mega || entry.mega,
+          count: Math.max(existing.count, entry.count),
+        }
+      : entry;
+  }
+
+  return merged;
+}
+
+/**
+ * Union, earliest timestamp wins.
+ *
+ * Earliest rather than latest because the stored time is when the player
+ * *earned* it, and syncing to a new device must not restamp a two-year-old
+ * unlock as today's.
+ */
+function mergeAchievements(
+  base: Record<string, string>,
+  incoming: Record<string, string>,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...base };
+
+  for (const [id, at] of Object.entries(incoming)) {
+    const existing = merged[id];
+    merged[id] = existing && existing <= at ? existing : at;
+  }
+
+  return merged;
+}
+
+/** Max, never lower. Two devices offline at once under-count; that trade is in `docs/sync.md`. */
+function mergeCounters(
+  base: Record<string, number>,
+  incoming: Record<string, number>,
+): Record<string, number> {
+  const merged: Record<string, number> = { ...base };
+
+  for (const [key, value] of Object.entries(incoming)) {
+    merged[key] = Math.max(merged[key] ?? 0, value);
+  }
+
+  return merged;
+}
+
+/**
+ * Reads a server response into a snapshot, keeping only what is well formed.
+ *
+ * Tolerant on purpose. The game deploys on every push to `main` and the API
+ * does not, so a response carrying a field this build has never heard of is
+ * the normal case rather than an error — and refusing to parse one would
+ * strand a player's collection on the server.
+ */
+export function parseSyncSnapshot(body: unknown): SyncSnapshot {
+  const source = isObject(body) ? body : {};
+
+  return {
+    pokedex: parsePokedex(source['pokedex']),
+    badges: Array.isArray(source['badges'])
+      ? source['badges'].filter((id): id is string => typeof id === 'string')
+      : [],
+    achievements: parseStringMap(source['achievements']),
+    counters: parseCounters(source['counters']),
+    settings: isObject(source['settings']) ? (source['settings'] as Partial<GameSettings>) : null,
+  };
+}
+
+function parsePokedex(value: unknown): Record<string, SyncPokedexEntry> {
+  if (!isObject(value)) {
+    return {};
+  }
+
+  const entries: Record<string, SyncPokedexEntry> = {};
+  for (const [id, entry] of Object.entries(value)) {
+    if (!isObject(entry)) {
+      continue;
+    }
+
+    // A row exists because the Pokémon was obtained at least once, so 1 is the
+    // floor and 0 is never meaningful.
+    const count = typeof entry['count'] === 'number' && entry['count'] > 0 ? Math.floor(entry['count']) : 1;
+
+    entries[id] = {
+      won: entry['won'] === true,
+      shiny: entry['shiny'] === true,
+      mega: entry['mega'] === true,
+      count,
+    };
+  }
+
+  return entries;
+}
+
+function parseStringMap(value: unknown): Record<string, string> {
+  if (!isObject(value)) {
+    return {};
+  }
+
+  const map: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'string') {
+      map[key] = item;
+    }
+  }
+
+  return map;
+}
+
+function parseCounters(value: unknown): Record<string, number> {
+  if (!isObject(value)) {
+    return {};
+  }
+
+  const counters: Record<string, number> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'number' && Number.isFinite(item) && item > 0) {
+      counters[key] = Math.floor(item);
+    }
+  }
+
+  return counters;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/app/services/sync-service/sync.service.spec.ts
+++ b/src/app/services/sync-service/sync.service.spec.ts
@@ -1,0 +1,188 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { SyncService, SyncStatus } from './sync.service';
+import { AuthService } from '../auth-service/auth.service';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
+import { PokedexService } from '../pokedex-service/pokedex.service';
+import { BadgeDexService } from '../badge-dex-service/badge-dex.service';
+import { StatsService } from '../stats-service/stats.service';
+import { AchievementService } from '../achievement-service/achievement.service';
+import { environment } from '../../../environments/environment';
+
+describe('SyncService', () => {
+  let sync: SyncService;
+  let auth: AuthService;
+  let http: HttpTestingController;
+  let syncState: SyncStateService;
+
+  const endpoint = `${environment.apiBaseUrl}/v1/sync`;
+  const user = { id: 'u1', email: 'ash@pallet.town' };
+
+  /** Signs in, which is what starts the client. */
+  const signIn = () => {
+    auth.refresh().subscribe();
+    http.expectOne(`${environment.apiBaseUrl}/v1/auth/me`).flush(user);
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    http = TestBed.inject(HttpTestingController);
+    auth = TestBed.inject(AuthService);
+    syncState = TestBed.inject(SyncStateService);
+    sync = TestBed.inject(SyncService);
+    sync.start();
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('pushes as soon as the player signs in', fakeAsync(() => {
+    TestBed.inject(StatsService).increment('spins_total', 7);
+
+    signIn();
+    tick();
+
+    const request = http.expectOne(endpoint);
+    expect(request.request.body.counters['spins_total']).toBe(7);
+    expect(request.request.withCredentials).toBeTrue();
+
+    request.flush({ counters: { spins_total: 7 } });
+    expect(syncState.isSynced).toBeTrue();
+  }));
+
+  it('merges the account into local state rather than replacing it', fakeAsync(() => {
+    // The whole point: a device that has never seen the other one must not
+    // lose its own collection by syncing, and must not lose the other's.
+    const pokedex = TestBed.inject(PokedexService);
+    pokedex.recordCatch(25);
+
+    signIn();
+    tick();
+
+    http.expectOne(endpoint).flush({
+      pokedex: { '6': { won: true, shiny: true, mega: false, count: 4 } },
+      badges: ['boulder'],
+    });
+
+    expect(pokedex.currentPokedex.caught['25'].count).toBe(1);
+    expect(pokedex.currentPokedex.caught['6'].shiny).toBeTrue();
+    expect(TestBed.inject(BadgeDexService).earned.has('boulder')).toBeTrue();
+  }));
+
+  it('does not report synced when something was caught mid-request', fakeAsync(() => {
+    signIn();
+    tick();
+
+    const request = http.expectOne(endpoint);
+    TestBed.inject(StatsService).increment('spins_total');
+    request.flush({});
+
+    expect(syncState.isSynced).toBeFalse();
+
+    // ...and pushes again, carrying the change that the first request missed.
+    tick(3000);
+    expect(http.expectOne(endpoint).request.body.counters['spins_total']).toBe(1);
+    tick();
+  }));
+
+  it('debounces a burst of changes into one request', fakeAsync(() => {
+    signIn();
+    tick();
+    http.expectOne(endpoint).flush({});
+
+    const stats = TestBed.inject(StatsService);
+    stats.increment('spins_total');
+    tick(500);
+    stats.increment('spins_total');
+    tick(500);
+    stats.increment('spins_total');
+
+    http.expectNone(endpoint);
+
+    tick(3000);
+    expect(http.expectOne(endpoint).request.body.counters['spins_total']).toBe(3);
+    tick();
+  }));
+
+  it('retries with backoff while offline, and loses nothing', fakeAsync(() => {
+    TestBed.inject(StatsService).increment('eggs_hatched', 3);
+
+    signIn();
+    tick();
+
+    http.expectOne(endpoint).error(new ProgressEvent('offline'), { status: 0 });
+    expect(status()).toBe('offline');
+    expect(syncState.isSynced).toBeFalse();
+
+    tick(5000);
+    http.expectOne(endpoint).error(new ProgressEvent('offline'), { status: 0 });
+
+    // Backoff: nothing at the previous interval, a retry at the doubled one.
+    tick(5000);
+    http.expectNone(endpoint);
+    tick(5000);
+
+    const retry = http.expectOne(endpoint);
+    expect(retry.request.body.counters['eggs_hatched']).toBe(3);
+    retry.flush({});
+
+    expect(syncState.isSynced).toBeTrue();
+    expect(status()).toBe('synced');
+  }));
+
+  it('stops syncing on a 401 but keeps local data', fakeAsync(() => {
+    TestBed.inject(StatsService).increment('spins_total', 5);
+
+    signIn();
+    tick();
+
+    http.expectOne(endpoint).flush(null, { status: 401, statusText: 'Unauthorized' });
+    http.expectOne(`${environment.apiBaseUrl}/v1/auth/me`).flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(status()).toBe('off');
+    expect(TestBed.inject(StatsService).get('spins_total')).toBe(5);
+
+    // No retry storm against a session that has ended.
+    tick(60000);
+    http.expectNone(endpoint);
+  }));
+
+  it('does not announce achievements the account already had', fakeAsync(() => {
+    // Adopting a collection re-runs evaluation, so the unlock record has to be
+    // in place first or a new device fires a toast for every old achievement.
+    const announced: string[] = [];
+    TestBed.inject(AchievementService).newlyUnlocked$.subscribe(
+      unlocked => announced.push(...unlocked.map(achievement => achievement.id)),
+    );
+
+    signIn();
+    tick();
+
+    http.expectOne(endpoint).flush({
+      pokedex: { '1': { won: true, count: 1 } },
+      achievements: { i_choose_you: '2020-01-01T00:00:00Z' },
+    });
+
+    expect(announced).toEqual([]);
+    expect(TestBed.inject(AchievementService).isUnlocked('i_choose_you')).toBeTrue();
+  }));
+
+  it('never syncs for a player with no account', fakeAsync(() => {
+    TestBed.inject(StatsService).increment('spins_total');
+    tick(60000);
+    http.expectNone(endpoint);
+    expect(status()).toBe('off');
+  }));
+
+  const status = (): SyncStatus => {
+    let current: SyncStatus = 'off';
+    sync.status$.subscribe(value => (current = value)).unsubscribe();
+    return current;
+  };
+});

--- a/src/app/services/sync-service/sync.service.ts
+++ b/src/app/services/sync-service/sync.service.ts
@@ -1,0 +1,253 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { BehaviorSubject, Observable, Subscription, timer } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+import { AuthService } from '../auth-service/auth.service';
+import { SyncStateService } from '../sync-state-service/sync-state.service';
+import { PokedexService, PokedexEntry } from '../pokedex-service/pokedex.service';
+import { BadgeDexService } from '../badge-dex-service/badge-dex.service';
+import { StatsService } from '../stats-service/stats.service';
+import { AchievementService } from '../achievement-service/achievement.service';
+import { SettingsService } from '../settings-service/settings.service';
+import { SyncSnapshot, mergeSnapshots, parseSyncSnapshot } from './sync-snapshot';
+
+/** What the account screen shows. Nothing more intrusive than this exists. */
+export type SyncStatus = 'off' | 'syncing' | 'synced' | 'pending' | 'offline';
+
+/** Debounce before pushing. A six-Pokémon run is one round trip, not six. */
+const PUSH_DEBOUNCE_MS = 3000;
+
+const FIRST_RETRY_MS = 5000;
+const MAX_RETRY_MS = 5 * 60 * 1000;
+
+/**
+ * Moves a player's collections between their devices.
+ *
+ * **There is no queue of mutations, and that is the design, not an omission.**
+ * The client sends *absolute state*: the whole collection, every time. So a
+ * request that failed needs no record of what it contained — the next push
+ * carries the same ground truth plus whatever happened since. One boolean
+ * (`SyncStateService`) replaces a durable outbox, retries are free because a
+ * repeat is a no-op, and there is nothing to deduplicate and nothing to sweep.
+ *
+ * The trade is written down in `docs/sync.md`: two devices playing offline
+ * *simultaneously* under-count, because counters merge by max rather than by
+ * summing deltas. Accepted, because the window needs two devices genuinely
+ * offline at once and the cost is a few counter ticks.
+ *
+ * **Every failure leaves the game fully playable.** Nothing here may throw into
+ * the game loop, block a spin, or show a player an error for a question they
+ * never asked.
+ */
+@Injectable({ providedIn: 'root' })
+export class SyncService {
+  private readonly endpoint = `${environment.apiBaseUrl}/v1/sync`;
+
+  private statusSubject$ = new BehaviorSubject<SyncStatus>('off');
+
+  private pending: Subscription | null = null;
+  private inFlight = false;
+  private retryDelay = FIRST_RETRY_MS;
+
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService,
+    private syncState: SyncStateService,
+    private pokedexService: PokedexService,
+    private badgeDexService: BadgeDexService,
+    private statsService: StatsService,
+    private achievementService: AchievementService,
+    private settingsService: SettingsService,
+  ) {}
+
+  get status$(): Observable<SyncStatus> {
+    return this.statusSubject$.asObservable();
+  }
+
+  /**
+   * Starts syncing. Called once, from the app root.
+   *
+   * Signing in pushes immediately, which is also how an anonymous player's
+   * collection reaches a brand new account: their local state is posted as an
+   * ordinary sync and unioned in. **Signing up is not a special case and must
+   * not get its own code path** — everything is grow-only, so "import my local
+   * data" and "sync" are the same operation.
+   */
+  start(): void {
+    this.authService.user$.subscribe(user => {
+      if (user) {
+        this.schedule(0);
+      } else {
+        this.cancel();
+        this.statusSubject$.next('off');
+      }
+    });
+
+    this.syncState.synced$.subscribe(synced => {
+      if (!synced && this.authService.isSignedIn) {
+        this.schedule(PUSH_DEBOUNCE_MS);
+      }
+    });
+  }
+
+  /** Pushes now, for the account screen's retry. Safe to call at any time. */
+  syncNow(): void {
+    if (this.authService.isSignedIn) {
+      this.schedule(0);
+    }
+  }
+
+  /**
+   * Erases every collection from this device.
+   *
+   * Signing out wipes local data, which is the opposite of the usual default
+   * and is deliberate: this game gets played on shared devices, and leaving a
+   * collection behind means the next person silently merges their progress
+   * into someone else's. Grow-only data cannot be separated back out
+   * afterwards, so the contamination would be permanent.
+   *
+   * Reloading afterwards rather than resetting each service in place: every
+   * service holds its state in memory, and a missed one would resurrect the
+   * previous player's Pokédex the next time it wrote to storage.
+   */
+  clearLocalDataAndReload(): void {
+    try {
+      localStorage.clear();
+    } catch (error) {
+      console.error('Failed to clear local data on sign out:', error);
+    }
+
+    window.location.reload();
+  }
+
+  private schedule(delayMs: number): void {
+    this.cancel();
+    this.pending = timer(delayMs).subscribe(() => this.push());
+  }
+
+  private cancel(): void {
+    this.pending?.unsubscribe();
+    this.pending = null;
+  }
+
+  private push(): void {
+    if (this.inFlight || !this.authService.isSignedIn) {
+      return;
+    }
+
+    this.inFlight = true;
+    this.statusSubject$.next('syncing');
+
+    const sent = this.snapshot();
+
+    this.http
+      .post(this.endpoint, sent, { withCredentials: true })
+      .subscribe({
+        next: body => {
+          this.inFlight = false;
+          this.retryDelay = FIRST_RETRY_MS;
+
+          // Whether anything was caught while the request was in the air.
+          // Compared before adopting, and between two snapshots built the same
+          // way, so the server having *more* than we sent does not read as a
+          // local change.
+          const changedDuringFlight = !sameSnapshot(sent, this.snapshot());
+
+          this.adopt(parseSyncSnapshot(body));
+
+          if (changedDuringFlight) {
+            this.statusSubject$.next('pending');
+            this.schedule(PUSH_DEBOUNCE_MS);
+          } else {
+            this.syncState.markSynced();
+            this.statusSubject$.next('synced');
+          }
+        },
+        error: (error: unknown) => {
+          this.inFlight = false;
+          this.onFailure(error);
+        },
+      });
+  }
+
+  /**
+   * Applies the server's answer, re-merged with whatever is local right now.
+   *
+   * The re-merge is not belt-and-braces. A push takes real time, and anything
+   * caught during it is in local state but not in the response — adopting the
+   * response alone would drop it, and the player would watch a Pokémon they
+   * just caught disappear. Merging is cheap and makes that window harmless.
+   */
+  private adopt(fromServer: SyncSnapshot): void {
+    const merged = mergeSnapshots(fromServer, this.snapshot());
+
+    // Achievements first: adopting a collection re-runs achievement
+    // evaluation, and doing that before the unlock record is in place would
+    // announce another device's months-old achievements as if earned now.
+    this.achievementService.adopt(merged.achievements);
+
+    this.pokedexService.adopt(toPokedexEntries(merged));
+    this.badgeDexService.adopt(merged.badges);
+    this.statsService.adopt(merged.counters);
+
+    if (merged.settings) {
+      this.settingsService.adopt(merged.settings);
+    }
+  }
+
+  private onFailure(error: unknown): void {
+    const status = error instanceof HttpErrorResponse ? error.status : 0;
+
+    // A session that ended mid-play. Stop syncing and let the account screen
+    // reflect it — but **keep local data**: only an explicit sign-out wipes,
+    // and a player whose cookie expired has not asked to lose anything.
+    if (status === 401) {
+      this.cancel();
+      this.statusSubject$.next('off');
+      this.authService.refresh().subscribe();
+      return;
+    }
+
+    this.statusSubject$.next(status === 0 ? 'offline' : 'pending');
+
+    this.schedule(this.retryDelay);
+    this.retryDelay = Math.min(this.retryDelay * 2, MAX_RETRY_MS);
+  }
+
+  private snapshot(): SyncSnapshot {
+    const pokedex: SyncSnapshot['pokedex'] = {};
+    for (const [id, entry] of Object.entries(this.pokedexService.currentPokedex.caught)) {
+      pokedex[id] = {
+        won: Boolean(entry.won),
+        shiny: Boolean(entry.shiny),
+        mega: Boolean(entry.mega),
+        count: entry.count && entry.count > 0 ? entry.count : 1,
+      };
+    }
+
+    return {
+      pokedex,
+      badges: [...this.badgeDexService.earned].sort(),
+      achievements: { ...this.achievementService.unlocked },
+      counters: { ...this.statsService.currentStats } as Record<string, number>,
+      settings: this.settingsService.currentSettings,
+    };
+  }
+}
+
+function toPokedexEntries(snapshot: SyncSnapshot): Record<string, PokedexEntry> {
+  const caught: Record<string, PokedexEntry> = {};
+  for (const [id, entry] of Object.entries(snapshot.pokedex)) {
+    caught[id] = { won: entry.won, shiny: entry.shiny, mega: entry.mega, count: entry.count };
+  }
+  return caught;
+}
+
+/**
+ * Enough for snapshots: plain JSON with no `undefined`, and both sides are
+ * built by the same function, so key order matches by construction.
+ */
+function sameSnapshot(a: SyncSnapshot, b: SyncSnapshot): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/src/app/settings/account/account.component.css
+++ b/src/app/settings/account/account.component.css
@@ -61,3 +61,20 @@
   align-self: flex-start;
   margin-top: 0.35rem;
 }
+
+.account-sync {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.account-sync-offline {
+  font-style: italic;
+}
+
+.account-retry {
+  padding: 0;
+  border: 0;
+  vertical-align: baseline;
+}

--- a/src/app/settings/account/account.component.html
+++ b/src/app/settings/account/account.component.html
@@ -9,20 +9,41 @@
       {{ 'account.signedInAs' | translate }} <strong>{{ user.email }}</strong>
     </p>
 
-    @if (hasUnsyncedProgress) {
-      <p class="account-warning">{{ 'account.unsyncedWarning' | translate }}</p>
-    }
+    <p class="account-note account-sync" [class.account-sync-offline]="syncStatus === 'offline'">
+      {{ 'account.sync.' + syncStatus | translate }}
+      @if (syncStatus === 'offline' || syncStatus === 'pending') {
+        <button type="button" class="btn btn-link btn-sm account-retry" (click)="retrySync()">
+          {{ 'account.sync.retry' | translate }}
+        </button>
+      }
+    </p>
 
-    <div class="account-actions">
-      <button type="button" class="btn btn-outline-secondary btn-sm"
-              [disabled]="busy" (click)="signOut()">
-        {{ 'account.signOut' | translate }}
-      </button>
-      <button type="button" class="btn btn-outline-secondary btn-sm"
-              [disabled]="busy" (click)="signOutEverywhere()">
-        {{ 'account.signOutEverywhere' | translate }}
-      </button>
-    </div>
+    @if (confirmingSignOut) {
+      <div class="account-form">
+        <p class="account-warning">{{ 'account.signOutUnsyncedWarning' | translate }}</p>
+        <div class="account-actions">
+          <button type="button" class="btn btn-danger btn-sm"
+                  [disabled]="busy" (click)="signOut()">
+            {{ 'account.signOutAnyway' | translate }}
+          </button>
+          <button type="button" class="btn btn-outline-secondary btn-sm"
+                  [disabled]="busy" (click)="cancelSignOut()">
+            {{ 'account.cancel' | translate }}
+          </button>
+        </div>
+      </div>
+    } @else {
+      <div class="account-actions">
+        <button type="button" class="btn btn-outline-secondary btn-sm"
+                [disabled]="busy" (click)="signOut()">
+          {{ 'account.signOut' | translate }}
+        </button>
+        <button type="button" class="btn btn-outline-secondary btn-sm"
+                [disabled]="busy" (click)="signOutEverywhere()">
+          {{ 'account.signOutEverywhere' | translate }}
+        </button>
+      </div>
+    }
 
     <p class="account-note">{{ 'account.signOutExplains' | translate }}</p>
 

--- a/src/app/settings/account/account.component.spec.ts
+++ b/src/app/settings/account/account.component.spec.ts
@@ -4,17 +4,27 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideTranslateService } from '@ngx-translate/core';
 
 import { AccountComponent } from './account.component';
+import { AuthService } from '../../services/auth-service/auth.service';
+import { SyncService } from '../../services/sync-service/sync.service';
+import { SyncStateService } from '../../services/sync-state-service/sync-state.service';
 import { environment } from '../../../environments/environment';
 
 describe('AccountComponent', () => {
   let fixture: ComponentFixture<AccountComponent>;
   let component: AccountComponent;
   let http: HttpTestingController;
+  let wipe: jasmine.Spy;
 
   const base = `${environment.apiBaseUrl}/v1`;
 
-  /** The "who am I" the component asks on load; answered signed-out by default. */
+  /**
+   * The "who am I" the app asks on startup; answered signed-out by default.
+   *
+   * Asked by the app root rather than by this component, so the spec plays the
+   * root's part.
+   */
   const answerWhoAmI = (user: unknown = null) => {
+    TestBed.inject(AuthService).refresh().subscribe();
     const request = http.expectOne(`${base}/auth/me`);
     if (user) {
       request.flush(user);
@@ -34,6 +44,11 @@ describe('AccountComponent', () => {
     }).compileComponents();
 
     http = TestBed.inject(HttpTestingController);
+
+    // Signing out and deleting both wipe this device and reload the page,
+    // which would take the test runner with them.
+    wipe = spyOn(TestBed.inject(SyncService), 'clearLocalDataAndReload');
+
     fixture = TestBed.createComponent(AccountComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -151,5 +166,35 @@ describe('AccountComponent', () => {
 
     expect(component.user).toBeNull();
     expect(component.confirmingDelete).toBeFalse();
+    expect(wipe).toHaveBeenCalled();
+  });
+
+  describe('signing out', () => {
+
+    it('asks first when progress has not reached the account', () => {
+      // Signing out clears this device, so unsynced progress dies with it.
+      answerWhoAmI({ id: 'abc', email: 'ash@pallet.town' });
+      TestBed.inject(SyncStateService).markDirty();
+
+      component.signOut();
+
+      http.expectNone(`${base}/auth/logout`);
+      expect(component.confirmingSignOut).toBeTrue();
+
+      component.signOut();
+      http.expectOne(`${base}/auth/logout`).flush(null);
+      expect(wipe).toHaveBeenCalled();
+    });
+
+    it('does not ask when everything is saved', () => {
+      answerWhoAmI({ id: 'abc', email: 'ash@pallet.town' });
+      TestBed.inject(SyncStateService).markSynced();
+
+      component.signOut();
+
+      expect(component.confirmingSignOut).toBeFalse();
+      http.expectOne(`${base}/auth/logout`).flush(null);
+      expect(wipe).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/settings/account/account.component.ts
+++ b/src/app/settings/account/account.component.ts
@@ -5,6 +5,7 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 
 import { AuthService, AuthUser } from '../../services/auth-service/auth.service';
 import { SyncStateService } from '../../services/sync-state-service/sync-state.service';
+import { SyncService, SyncStatus } from '../../services/sync-service/sync.service';
 
 /** Matches the backend, which rejects anything shorter. */
 const MIN_PASSWORD_LENGTH = 12;
@@ -37,6 +38,7 @@ export class AccountComponent implements OnInit, OnDestroy {
   constructor(
     private authService: AuthService,
     private syncState: SyncStateService,
+    private syncService: SyncService,
     private translate: TranslateService,
   ) {}
 
@@ -48,6 +50,8 @@ export class AccountComponent implements OnInit, OnDestroy {
   busy = false;
   error = '';
   confirmingDelete = false;
+  confirmingSignOut = false;
+  syncStatus: SyncStatus = 'off';
 
   // Two text fields and a password confirmation. A forms module for this would
   // be 4.5 kB of framework to validate an email and count characters — enough
@@ -62,11 +66,7 @@ export class AccountComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.subscriptions.add(this.authService.user$.subscribe(user => (this.user = user)));
     this.subscriptions.add(this.authService.checked$.subscribe(checked => (this.checked = checked)));
-
-    // Asked here rather than at app start: a player who never opens Settings
-    // never causes a request, and the answer is only needed on this screen
-    // until the sync client lands.
-    this.subscriptions.add(this.authService.refresh().subscribe());
+    this.subscriptions.add(this.syncService.status$.subscribe(status => (this.syncStatus = status)));
   }
 
   ngOnDestroy(): void {
@@ -114,12 +114,37 @@ export class AccountComponent implements OnInit, OnDestroy {
     });
   }
 
+  retrySync(): void {
+    this.syncService.syncNow();
+  }
+
+  /**
+   * Signing out wipes this device.
+   *
+   * Unsynced progress is therefore destroyed by it, so that case asks first —
+   * "you have progress not yet saved to your account" is a sentence a player
+   * needs to read before, not after.
+   */
   signOut(): void {
-    this.run(this.authService.logout(), 'account.error.generic');
+    if (this.hasUnsyncedProgress && !this.confirmingSignOut) {
+      this.confirmingSignOut = true;
+      return;
+    }
+
+    this.run(this.authService.logout(), 'account.error.generic', () => this.wipe());
   }
 
   signOutEverywhere(): void {
-    this.run(this.authService.logoutEverywhere(), 'account.error.generic');
+    if (this.hasUnsyncedProgress && !this.confirmingSignOut) {
+      this.confirmingSignOut = true;
+      return;
+    }
+
+    this.run(this.authService.logoutEverywhere(), 'account.error.generic', () => this.wipe());
+  }
+
+  cancelSignOut(): void {
+    this.confirmingSignOut = false;
   }
 
   deleteAccount(): void {
@@ -130,7 +155,12 @@ export class AccountComponent implements OnInit, OnDestroy {
     this.run(this.authService.deleteAccount(this.deletePassword), 'account.error.generic', () => {
       this.deletePassword = '';
       this.confirmingDelete = false;
+      this.wipe();
     });
+  }
+
+  private wipe(): void {
+    this.syncService.clearLocalDataAndReload();
   }
 
   /**

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3071,14 +3071,23 @@
     "signOut": "Abmelden",
     "signOutEverywhere": "Überall abmelden",
     "signOutExplains": "Beim Abmelden wird deine Sammlung von diesem Gerät entfernt. Sie bleibt in deinem Konto und kehrt bei der nächsten Anmeldung zurück.",
-    "unsyncedWarning": "Ein Teil des Fortschritts hat dein Konto noch nicht erreicht. Wenn du dich jetzt abmeldest, geht er verloren.",
     "delete": "Konto löschen",
     "deleteConfirm": "Endgültig löschen",
     "cancel": "Abbrechen",
     "deleteWarning": "Damit werden dein Konto und alle Inhalte endgültig gelöscht. Gib zur Bestätigung dein Passwort ein.",
     "error": {
       "generic": "Das hat nicht geklappt. Bitte versuche es erneut."
-    }
+    },
+    "sync": {
+      "off": "Keine Synchronisierung.",
+      "syncing": "Wird in deinem Konto gespeichert…",
+      "synced": "Alles ist in deinem Konto gespeichert.",
+      "pending": "Ein Teil deines Fortschritts hat dein Konto noch nicht erreicht.",
+      "offline": "Offline. Dein Fortschritt ist hier sicher und wird gespeichert, sobald du wieder online bist.",
+      "retry": "Jetzt versuchen"
+    },
+    "signOutUnsyncedWarning": "Ein Teil deines Fortschritts hat dein Konto noch nicht erreicht, und das Abmelden löscht dieses Gerät. Dieser Fortschritt geht verloren.",
+    "signOutAnyway": "Trotzdem abmelden"
   },
   "detail": {
     "name": "Name",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3071,14 +3071,23 @@
     "signOut": "Sign out",
     "signOutEverywhere": "Sign out everywhere",
     "signOutExplains": "Signing out removes your collection from this device. It stays on your account, and comes back when you sign in.",
-    "unsyncedWarning": "Some progress has not reached your account yet. Sign out and it will be lost.",
     "delete": "Delete account",
     "deleteConfirm": "Delete permanently",
     "cancel": "Cancel",
     "deleteWarning": "This deletes your account and everything in it, permanently. Enter your password to confirm.",
     "error": {
       "generic": "That did not work. Please try again."
-    }
+    },
+    "sync": {
+      "off": "Not syncing.",
+      "syncing": "Saving to your account…",
+      "synced": "Everything is saved to your account.",
+      "pending": "Some progress has not reached your account yet.",
+      "offline": "Offline. Your progress is safe here and will be saved when you reconnect.",
+      "retry": "Try now"
+    },
+    "signOutUnsyncedWarning": "Some progress has not reached your account yet, and signing out clears this device. That progress will be lost.",
+    "signOutAnyway": "Sign out anyway"
   },
   "detail": {
     "name": "Name",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3071,14 +3071,23 @@
     "signOut": "Cerrar sesión",
     "signOutEverywhere": "Cerrar sesión en todos los dispositivos",
     "signOutExplains": "Cerrar sesión elimina tu colección de este dispositivo. Permanece en tu cuenta y vuelve cuando inicies sesión.",
-    "unsyncedWarning": "Parte del progreso aún no ha llegado a tu cuenta. Si cierras sesión ahora, se perderá.",
     "delete": "Eliminar cuenta",
     "deleteConfirm": "Eliminar permanentemente",
     "cancel": "Cancelar",
     "deleteWarning": "Esto elimina tu cuenta y todo su contenido, de forma permanente. Escribe tu contraseña para confirmar.",
     "error": {
       "generic": "No ha funcionado. Inténtalo de nuevo."
-    }
+    },
+    "sync": {
+      "off": "Sin sincronizar.",
+      "syncing": "Guardando en tu cuenta…",
+      "synced": "Todo está guardado en tu cuenta.",
+      "pending": "Parte de tu progreso aún no ha llegado a tu cuenta.",
+      "offline": "Sin conexión. Tu progreso está a salvo aquí y se guardará cuando vuelvas a conectarte.",
+      "retry": "Intentar ahora"
+    },
+    "signOutUnsyncedWarning": "Parte de tu progreso aún no ha llegado a tu cuenta, y cerrar sesión borra este dispositivo. Ese progreso se perderá.",
+    "signOutAnyway": "Cerrar sesión de todos modos"
   },
   "detail": {
     "name": "Nombre",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -3071,14 +3071,23 @@
     "signOut": "Se déconnecter",
     "signOutEverywhere": "Se déconnecter partout",
     "signOutExplains": "La déconnexion retire votre collection de cet appareil. Elle reste sur votre compte et revient à la reconnexion.",
-    "unsyncedWarning": "Une partie de la progression n'a pas encore atteint votre compte. Si vous vous déconnectez maintenant, elle sera perdue.",
     "delete": "Supprimer le compte",
     "deleteConfirm": "Supprimer définitivement",
     "cancel": "Annuler",
     "deleteWarning": "Ceci supprime votre compte et tout son contenu, définitivement. Saisissez votre mot de passe pour confirmer.",
     "error": {
       "generic": "Cela n'a pas fonctionné. Veuillez réessayer."
-    }
+    },
+    "sync": {
+      "off": "Pas de synchronisation.",
+      "syncing": "Enregistrement sur votre compte…",
+      "synced": "Tout est enregistré sur votre compte.",
+      "pending": "Une partie de votre progression n'a pas encore atteint votre compte.",
+      "offline": "Hors ligne. Votre progression est en sécurité ici et sera enregistrée à la reconnexion.",
+      "retry": "Réessayer maintenant"
+    },
+    "signOutUnsyncedWarning": "Une partie de votre progression n'a pas encore atteint votre compte, et la déconnexion efface cet appareil. Cette progression sera perdue.",
+    "signOutAnyway": "Se déconnecter quand même"
   },
   "detail": {
     "name": "Nom",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3071,14 +3071,23 @@
     "signOut": "Esci",
     "signOutEverywhere": "Esci da tutti i dispositivi",
     "signOutExplains": "Uscendo, la tua collezione viene rimossa da questo dispositivo. Resta nel tuo account e torna quando accedi di nuovo.",
-    "unsyncedWarning": "Parte dei progressi non ha ancora raggiunto il tuo account. Se esci ora, andranno persi.",
     "delete": "Elimina account",
     "deleteConfirm": "Elimina definitivamente",
     "cancel": "Annulla",
     "deleteWarning": "Questo elimina il tuo account e tutto il suo contenuto, definitivamente. Inserisci la password per confermare.",
     "error": {
       "generic": "Non ha funzionato. Riprova."
-    }
+    },
+    "sync": {
+      "off": "Nessuna sincronizzazione.",
+      "syncing": "Salvataggio sul tuo account…",
+      "synced": "Tutto è salvato sul tuo account.",
+      "pending": "Una parte dei tuoi progressi non ha ancora raggiunto il tuo account.",
+      "offline": "Offline. I tuoi progressi sono al sicuro qui e verranno salvati quando tornerai online.",
+      "retry": "Riprova ora"
+    },
+    "signOutUnsyncedWarning": "Una parte dei tuoi progressi non ha ancora raggiunto il tuo account, e disconnettersi cancella questo dispositivo. Quei progressi andranno persi.",
+    "signOutAnyway": "Disconnetti comunque"
   },
   "detail": {
     "name": "Nome",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3071,14 +3071,23 @@
     "signOut": "Sair",
     "signOutEverywhere": "Sair de todos os dispositivos",
     "signOutExplains": "Sair remove sua coleção deste dispositivo. Ela continua na sua conta e volta quando você entrar novamente.",
-    "unsyncedWarning": "Parte do progresso ainda não chegou à sua conta. Se você sair agora, será perdido.",
     "delete": "Excluir conta",
     "deleteConfirm": "Excluir permanentemente",
     "cancel": "Cancelar",
     "deleteWarning": "Isso exclui sua conta e tudo nela, permanentemente. Digite sua senha para confirmar.",
     "error": {
       "generic": "Não funcionou. Tente novamente."
-    }
+    },
+    "sync": {
+      "off": "Sem sincronização.",
+      "syncing": "Salvando na sua conta…",
+      "synced": "Tudo está salvo na sua conta.",
+      "pending": "Parte do seu progresso ainda não chegou à sua conta.",
+      "offline": "Sem conexão. Seu progresso está seguro aqui e será salvo quando você reconectar.",
+      "retry": "Tentar agora"
+    },
+    "signOutUnsyncedWarning": "Parte do seu progresso ainda não chegou à sua conta, e sair apaga este dispositivo. Esse progresso será perdido.",
+    "signOutAnyway": "Sair mesmo assim"
   },
   "detail": {
     "name": "Nome",


### PR DESCRIPTION
Closes #57. **506/506 tests**, build green at **1.55 MB**, i18n parity at **2377**.

## There is no queue of mutations

The issue asked for an offline queue with per-mutation retry and client-generated idempotency keys. The contract that replaced it (`docs/sync.md`) sends **absolute state** — the whole collection, every time — and that removes the need for all three.

A failed request needs no record of what it held: the next push carries the same ground truth plus whatever happened since. One boolean stands in for a durable outbox, a retry is a no-op *by construction*, and there is nothing to deduplicate and nothing to sweep. There's a test pinning the idempotency so nobody reintroduces summing later.

The trade is real and stated rather than hidden: **two devices playing offline simultaneously under-count**, because counters merge by max rather than by summing deltas. The window needs two devices genuinely offline at once; the cost is a few counter ticks against a dedupe table on every single write.

## Verified against a real backend

Specs alone can't tell you the merge rules are right, so I ran all four scenarios through the actual UI and checked Postgres each time.

**Anonymous collection → brand new account, no importer.** Seeded a Pokédex, badges and counters as a signed-out player, created an account, and the whole lot arrived:

```
       email        | pokedex | badges | counters
 misty@cerulean.gym |       2 |      2 |        3
```

**Sign-out wipes the device.** Afterwards `localStorage` held one key — the theme, rewritten by its own service after the reload. Pokédex, badges, counters and the synced flag all gone.

**Second device with a divergent Pokédex converges — on both sides.** Device two had Pikachu at `won:false, shiny:false, count:9`; the account had `won:true, shiny:true, count:3`.

| | before | after |
|---|---|---|
| Pikachu | `false / false / 9` vs `true / true / 3` | `won:true, shiny:true, count:9` |
| Charizard | account only | on the device |
| Mewtwo | device only | on the account |
| `spins_total` | 10 vs 42 | 42 |
| badges | 1 vs 2 | 3 |

The `false` did not clear the shiny, which is the failure this whole design exists to prevent.

**Outage mid-session.** Stopped the API, toggled a setting, and got *"Offline. Your progress is safe here and will be saved when you reconnect."* with `synced: false` and the change intact. Restarted it and the backoff retry drained on its own, with no interaction.

## Where the code went

`sync-snapshot.ts` is pure — no Angular in it — because the merge rules *are* the product here, and **#59 has to reuse them** rather than grow a second implementation that drifts.

Each collection service gained an `adopt` that writes merged state **without** marking dirty; otherwise syncing would schedule another sync forever. Achievements are adopted **first**, and that ordering is load-bearing: every collection emission re-runs evaluation, so adopting another device's Pokédex before its unlock record would fire fifty toasts for things earned months ago on that device. There's a test.

`SettingsService` now marks dirty at all, which it never did — settings were silently never syncing. Its load-time validation is now shared with `adopt` instead of duplicated.

## Two judgment calls worth your eye

**Signing out reloads the page** after wiping. Each service holds its state in memory, and a missed one would resurrect the previous player's Pokédex on its next write. Unsynced progress asks for confirmation before any of it happens.

**Theme survives sign-out in practice** — it's wiped with everything else, then immediately rewritten at its default by `ThemeService`. That's open question 1 in `docs/sync.md` answered by accident rather than on purpose; say the word if you'd rather it were deliberate either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)