### PR TITLE
UAT round 1: account and settings fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ npm run deploy                                   # gh-pages, base-href /pokemon-
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
 
-**Green baseline:** build passes, **519/519 tests pass**. Any change must leave both green.
+**Green baseline:** build passes, **524/524 tests pass**. Any change must leave both green.
 
 ### Local environment gotchas
 
@@ -219,7 +219,7 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 
 Six locales in `src/assets/i18n/*.json` (en, pt, es, fr, de, it), loaded over HTTP by `TranslateHttpLoader`. User-facing strings are **never** literals — data files store dotted keys (`items.potion.name`, `game.main.roulette.fishing.title`) that templates resolve with the `translate` pipe. Adding a string means adding it to all six files.
 
-**All six files hold an identical key set** (2,379 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
+**All six files hold an identical key set** (2,381 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
 
 ```bash
 node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"

--- a/src/app/services/sync-service/sync.service.spec.ts
+++ b/src/app/services/sync-service/sync.service.spec.ts
@@ -180,6 +180,26 @@ describe('SyncService', () => {
     expect(status()).toBe('off');
   }));
 
+  it('keeps preferences but no collections when the player signs out', () => {
+    // The shared-device reasoning that justifies wiping a Pokédex does not
+    // reach a theme: nobody is contaminated by inheriting dark mode, and
+    // wiping it signed a Brazilian player out into an English, light game.
+    localStorage.setItem('pokemon-roulette-settings', '{"muteAudio":true}');
+    localStorage.setItem('pokemon-roulette-theme', 'plain-dark');
+    localStorage.setItem('language', 'pt');
+    localStorage.setItem('pokemon-roulette-pokedex', '{"caught":{"25":{"won":true}}}');
+    localStorage.setItem('pokemon-roulette-stats', '{"spins_total":9}');
+    localStorage.setItem('pokemon-roulette-badge-dex', '["boulder"]');
+    localStorage.setItem('pokemon-roulette-achievements', '{"i_choose_you":"2026-01-01T00:00:00Z"}');
+    localStorage.setItem('pokemon-roulette-synced', 'true');
+
+    sync.clearLocalData();
+
+    expect(Object.keys(localStorage).sort()).toEqual([
+      'language', 'pokemon-roulette-settings', 'pokemon-roulette-theme',
+    ]);
+  });
+
   const status = (): SyncStatus => {
     let current: SyncStatus = 'off';
     sync.status$.subscribe(value => (current = value)).unsubscribe();

--- a/src/app/services/sync-service/sync.service.ts
+++ b/src/app/services/sync-service/sync.service.ts
@@ -12,6 +12,21 @@ import { AchievementService } from '../achievement-service/achievement.service';
 import { SettingsService } from '../settings-service/settings.service';
 import { SyncSnapshot, mergeSnapshots, parseSyncSnapshot } from './sync-snapshot';
 
+/**
+ * Preferences, which survive signing out. Everything else is a collection and
+ * is wiped.
+ *
+ * An allowlist rather than a denylist on purpose: a new *collection* added to
+ * storage and forgotten about must default to being wiped, because leaving it
+ * behind is the failure that cannot be undone. A new preference forgotten
+ * about is merely reset.
+ */
+const KEPT_ON_SIGN_OUT: ReadonlySet<string> = new Set([
+  'pokemon-roulette-settings',
+  'pokemon-roulette-theme',
+  'language',
+]);
+
 /** What the account screen shows. Nothing more intrusive than this exists. */
 export type SyncStatus = 'off' | 'syncing' | 'synced' | 'pending' | 'offline';
 
@@ -99,26 +114,39 @@ export class SyncService {
   }
 
   /**
-   * Erases every collection from this device.
+   * Erases every collection from this device, and keeps the preferences.
    *
-   * Signing out wipes local data, which is the opposite of the usual default
+   * Signing out wipes collections, which is the opposite of the usual default
    * and is deliberate: this game gets played on shared devices, and leaving a
-   * collection behind means the next person silently merges their progress
-   * into someone else's. Grow-only data cannot be separated back out
-   * afterwards, so the contamination would be permanent.
+   * Pokédex behind means the next person silently merges their progress into
+   * someone else's. Grow-only data cannot be separated back out afterwards,
+   * so the contamination would be permanent.
+   *
+   * **Preferences are not collections and are kept.** Nobody is harmed by
+   * inheriting a dark theme, and wiping them meant a Brazilian player in dark
+   * mode signed out into an English, light game every time. The line is
+   * whether the data is *about the player* or about this browser.
    *
    * Reloading afterwards rather than resetting each service in place: every
    * service holds its state in memory, and a missed one would resurrect the
    * previous player's Pokédex the next time it wrote to storage.
    */
   clearLocalDataAndReload(): void {
+    this.clearLocalData();
+    window.location.reload();
+  }
+
+  /** The wipe itself, without the reload, so it can be tested. */
+  clearLocalData(): void {
     try {
-      localStorage.clear();
+      for (const key of Object.keys(localStorage)) {
+        if (!KEPT_ON_SIGN_OUT.has(key)) {
+          localStorage.removeItem(key);
+        }
+      }
     } catch (error) {
       console.error('Failed to clear local data on sign out:', error);
     }
-
-    window.location.reload();
   }
 
   private schedule(delayMs: number): void {

--- a/src/app/settings/account/account.component.css
+++ b/src/app/settings/account/account.component.css
@@ -78,3 +78,7 @@
   border: 0;
   vertical-align: baseline;
 }
+
+.account-mismatch {
+  color: #dc3545;
+}

--- a/src/app/settings/account/account.component.html
+++ b/src/app/settings/account/account.component.html
@@ -110,9 +110,25 @@
       </small>
 
       @if (mode === 'signup') {
+        <label class="account-label" for="account-password-confirm">
+          {{ 'account.confirmPassword' | translate }}
+        </label>
+        <input id="account-password-confirm" class="form-control form-control-sm"
+               type="password" autocomplete="new-password"
+               [class.is-invalid]="touched && !confirmationValid"
+               [value]="passwordConfirmation"
+               (input)="passwordConfirmation = $any($event.target).value"
+               (keyup.enter)="submit()">
+        @if (touched && !confirmationValid) {
+          <small class="account-hint account-mismatch">
+            {{ 'account.passwordMismatch' | translate }}
+          </small>
+        }
+
         <!-- Stated at the point of signup, not buried. There is no SMTP, so a
              forgotten password is an unrecoverable account, and someone could
-             lose a 900-Pokémon Pokédex to it. -->
+             lose a 900-Pokémon Pokédex to it. That is also why the password is
+             asked for twice: a typo here is an account nobody can open. -->
         <p class="account-warning">{{ 'account.noResetWarning' | translate }}</p>
       }
 
@@ -127,6 +143,13 @@
   }
 
   @if (error) {
-    <p class="account-error" role="alert">{{ error }}</p>
+    <p class="account-error" role="alert">
+      {{ error }}
+      @if (emailTaken) {
+        <button type="button" class="btn btn-link btn-sm account-retry" (click)="switchToSignIn()">
+          {{ 'account.signIn' | translate }}
+        </button>
+      }
+    </p>
   }
 </section>

--- a/src/app/settings/account/account.component.spec.ts
+++ b/src/app/settings/account/account.component.spec.ts
@@ -118,9 +118,78 @@ describe('AccountComponent', () => {
     component.setMode('signup');
     component.email = 'new@pallet.town';
     component.password = 'a-long-enough-password';
+    component.passwordConfirmation = 'a-long-enough-password';
     component.submit();
 
     http.expectOne(`${base}/auth/signup`).flush({ id: 'abc', email: 'new@pallet.town' });
+  });
+
+  describe('signing up', () => {
+
+    it('will not submit until the password is typed twice and matches', () => {
+      // There is no password reset, so a typo in a single field would be an
+      // account nobody can ever open.
+      answerWhoAmI();
+
+      component.setMode('signup');
+      component.email = 'new@pallet.town';
+      component.password = 'a-long-enough-password';
+      component.passwordConfirmation = 'a-long-enough-passwrod';
+      component.submit();
+
+      http.expectNone(`${base}/auth/signup`);
+      expect(component.confirmationValid).toBeFalse();
+
+      component.passwordConfirmation = 'a-long-enough-password';
+      component.submit();
+      http.expectOne(`${base}/auth/signup`).flush({ id: 'abc', email: 'new@pallet.town' });
+    });
+
+    it('does not ask for a confirmation when signing in', () => {
+      answerWhoAmI();
+
+      component.email = 'ash@pallet.town';
+      component.password = 'a-long-enough-password';
+
+      expect(component.confirmationValid).toBeTrue();
+      expect(component.canSubmit).toBeTrue();
+    });
+
+    it('accepts eight characters, as the server now does', () => {
+      answerWhoAmI();
+
+      component.email = 'new@pallet.town';
+      component.password = '12345678';
+
+      expect(component.passwordValid).toBeTrue();
+
+      component.password = '1234567';
+      expect(component.passwordValid).toBeFalse();
+    });
+
+    it('offers to sign in when the address is already registered', () => {
+      answerWhoAmI();
+
+      component.setMode('signup');
+      component.email = 'ash@pallet.town';
+      component.password = 'a-long-enough-password';
+      component.passwordConfirmation = 'a-long-enough-password';
+      component.submit();
+
+      http.expectOne(`${base}/auth/signup`).flush(
+        { error: { code: 'conflict', message: 'An account with that email already exists. Sign in instead.' } },
+        { status: 409, statusText: 'Conflict' },
+      );
+      fixture.detectChanges();
+
+      expect(component.emailTaken).toBeTrue();
+
+      // The button keeps what was typed rather than making them start again.
+      component.switchToSignIn();
+      expect(component.mode).toBe('signin');
+      expect(component.email).toBe('ash@pallet.town');
+      expect(component.password).toBe('a-long-enough-password');
+    });
   });
 
   // Rewording here would undo the server's deliberate refusal to say which of

--- a/src/app/settings/account/account.component.ts
+++ b/src/app/settings/account/account.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, Subscription } from 'rxjs';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 
@@ -8,7 +9,7 @@ import { SyncStateService } from '../../services/sync-state-service/sync-state.s
 import { SyncService, SyncStatus } from '../../services/sync-service/sync.service';
 
 /** Matches the backend, which rejects anything shorter. */
-const MIN_PASSWORD_LENGTH = 12;
+const MIN_PASSWORD_LENGTH = 8;
 
 /**
  * Permissive on purpose, like the server's own check: this rejects nonsense
@@ -58,8 +59,15 @@ export class AccountComponent implements OnInit, OnDestroy {
   // to breach the bundle budget on its own.
   email = '';
   password = '';
+  // Signup only. There is no password reset, so a typo in the one field would
+  // be an account nobody can ever open -- which is the whole reason to ask
+  // twice. Signing in does not need it: getting it wrong there just fails.
+  passwordConfirmation = '';
   deletePassword = '';
   touched = false;
+
+  /** Set when signup was refused because the address is already registered. */
+  emailTaken = false;
 
   private readonly subscriptions = new Subscription();
 
@@ -81,6 +89,17 @@ export class AccountComponent implements OnInit, OnDestroy {
     this.mode = mode;
     this.error = '';
     this.touched = false;
+    this.emailTaken = false;
+    this.passwordConfirmation = '';
+  }
+
+  /** Offered when signup reports the address is taken; keeps what was typed. */
+  switchToSignIn(): void {
+    const email = this.email;
+    const password = this.password;
+    this.setMode('signin');
+    this.email = email;
+    this.password = password;
   }
 
   get emailValid(): boolean {
@@ -91,12 +110,17 @@ export class AccountComponent implements OnInit, OnDestroy {
     return this.password.length >= MIN_PASSWORD_LENGTH;
   }
 
+  get confirmationValid(): boolean {
+    return this.mode === 'signin' || this.passwordConfirmation === this.password;
+  }
+
   get canSubmit(): boolean {
-    return this.emailValid && this.passwordValid && !this.busy;
+    return this.emailValid && this.passwordValid && this.confirmationValid && !this.busy;
   }
 
   submit(): void {
     this.touched = true;
+    this.emailTaken = false;
 
     if (!this.canSubmit) {
       return;
@@ -110,6 +134,7 @@ export class AccountComponent implements OnInit, OnDestroy {
     this.run(request, 'account.error.generic', () => {
       this.email = '';
       this.password = '';
+      this.passwordConfirmation = '';
       this.touched = false;
     });
   }
@@ -182,6 +207,9 @@ export class AccountComponent implements OnInit, OnDestroy {
       error: (failure: unknown) => {
         this.busy = false;
         this.error = AuthService.messageFor(failure, this.translate.instant(fallbackKey) as string);
+        // The server's message says "Sign in instead"; this is the button
+        // that does it, rather than making them find the tab and retype.
+        this.emailTaken = failure instanceof HttpErrorResponse && failure.status === 409;
       },
     });
   }

--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -1,0 +1,32 @@
+/*
+ * Bootstrap's `.form-switch` assumes the input comes first inside a
+ * `.form-check` and pulls it 2.5em to the left to sit in that padding. These
+ * rows put the label first instead, so the negative margin drags the switch
+ * back over the end of the label text.
+ *
+ * Invisible in English, where every label is short. In German at 375px it ate
+ * the last word: "Mega-Entwicklungsanimation überspringen" was clipped
+ * mid-word by its own switch.
+ */
+.form-switch.d-flex {
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.form-switch.d-flex .form-check-input {
+  margin-left: 0;
+  flex: none;
+}
+
+.form-switch.d-flex .form-check-label {
+  /* min-width lets a long label wrap instead of forcing the row wider. */
+  flex: 1;
+  min-width: 0;
+}
+
+/* The gender radios are a different Bootstrap structure, and the longest
+   label ("Immer Mädchen") ends up flush against its control. Not a collision,
+   but nothing should touch. */
+.form-check .form-check-label {
+  padding-left: 0.35rem;
+}

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3087,7 +3087,9 @@
       "retry": "Jetzt versuchen"
     },
     "signOutUnsyncedWarning": "Ein Teil deines Fortschritts hat dein Konto noch nicht erreicht, und das Abmelden löscht dieses Gerät. Dieser Fortschritt geht verloren.",
-    "signOutAnyway": "Trotzdem abmelden"
+    "signOutAnyway": "Trotzdem abmelden",
+    "confirmPassword": "Passwort bestätigen",
+    "passwordMismatch": "Die beiden Passwörter stimmen nicht überein."
   },
   "detail": {
     "name": "Name",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3087,7 +3087,9 @@
       "retry": "Try now"
     },
     "signOutUnsyncedWarning": "Some progress has not reached your account yet, and signing out clears this device. That progress will be lost.",
-    "signOutAnyway": "Sign out anyway"
+    "signOutAnyway": "Sign out anyway",
+    "confirmPassword": "Confirm password",
+    "passwordMismatch": "The two passwords do not match."
   },
   "detail": {
     "name": "Name",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3087,7 +3087,9 @@
       "retry": "Intentar ahora"
     },
     "signOutUnsyncedWarning": "Parte de tu progreso aún no ha llegado a tu cuenta, y cerrar sesión borra este dispositivo. Ese progreso se perderá.",
-    "signOutAnyway": "Cerrar sesión de todos modos"
+    "signOutAnyway": "Cerrar sesión de todos modos",
+    "confirmPassword": "Confirmar contraseña",
+    "passwordMismatch": "Las dos contraseñas no coinciden."
   },
   "detail": {
     "name": "Nombre",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -3087,7 +3087,9 @@
       "retry": "Réessayer maintenant"
     },
     "signOutUnsyncedWarning": "Une partie de votre progression n'a pas encore atteint votre compte, et la déconnexion efface cet appareil. Cette progression sera perdue.",
-    "signOutAnyway": "Se déconnecter quand même"
+    "signOutAnyway": "Se déconnecter quand même",
+    "confirmPassword": "Confirmer le mot de passe",
+    "passwordMismatch": "Les deux mots de passe ne correspondent pas."
   },
   "detail": {
     "name": "Nom",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3087,7 +3087,9 @@
       "retry": "Riprova ora"
     },
     "signOutUnsyncedWarning": "Una parte dei tuoi progressi non ha ancora raggiunto il tuo account, e disconnettersi cancella questo dispositivo. Quei progressi andranno persi.",
-    "signOutAnyway": "Disconnetti comunque"
+    "signOutAnyway": "Disconnetti comunque",
+    "confirmPassword": "Conferma password",
+    "passwordMismatch": "Le due password non coincidono."
   },
   "detail": {
     "name": "Nome",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3087,7 +3087,9 @@
       "retry": "Tentar agora"
     },
     "signOutUnsyncedWarning": "Parte do seu progresso ainda não chegou à sua conta, e sair apaga este dispositivo. Esse progresso será perdido.",
-    "signOutAnyway": "Sair mesmo assim"
+    "signOutAnyway": "Sair mesmo assim",
+    "confirmPassword": "Confirmar senha",
+    "passwordMismatch": "As duas senhas não coincidem."
   },
   "detail": {
     "name": "Nome",


### PR DESCRIPTION
Pairs with [backend #37](https://github.com/zeroxm/pokemon-roulette-backend/pull/37) — merge that first, since the 8-character minimum and the new conflict message come from it. **524/524 tests**, i18n parity at **2,381**.

Verified in a browser against a locally built backend carrying that PR, not only in specs.

## Settings labels no longer collide with their switches

Bootstrap's `.form-switch` assumes the input comes *first* inside a `.form-check` and pulls it 2.5em left to sit in that padding. These rows put the label first, so the negative margin dragged the switch back over the end of the text.

Invisible in English, which is why it survived. In German at 375px it clipped **"Mega-Entwicklungsanimation überspringen"** mid-word with its own control. Every switch label now has 12px of clearance and wraps instead; the gender radios got a little padding too, where "Immer Mädchen" sat flush against its button.

## Signup asks for the password twice

Your call, and it closes the worst hole on this screen: there is no password reset, so **a typo in a single password field is an account nobody can ever open.** Sign-in doesn't ask — getting it wrong there just fails harmlessly.

Verified live: a mismatch is blocked with "The two passwords do not match.", and an 8-character password is accepted.

## A taken address now offers a way forward

The API says *"An account with that email already exists. Sign in instead."*, so a 409 puts a **button** next to that message which switches to the sign-in tab and keeps what was already typed, rather than making them find the tab and retype it.

## Signing out keeps preferences, wipes collections

It wiped everything, so a Brazilian player in dark mode signed out into an **English, light** game every time. The shared-device reasoning that justifies destroying a Pokédex doesn't reach a theme — nobody is contaminated by inheriting dark mode.

The kept set is an **allowlist**, deliberately: a *collection* added later and forgotten about then defaults to being wiped, because leaving one behind is the failure that can't be undone. A preference forgotten about is merely reset.

Verified live: after signing out, storage held exactly `language`, `pokemon-roulette-settings` and `pokemon-roulette-theme`, the Pokédex was gone, and the page stayed in Portuguese.

## What this turned up — filed, not fixed here

With the UI in Portuguese, the taken-email error rendered in **English**, next to a button reading "Entrar". Every server-side error message is English-only and we show them verbatim by design. Filed on #71, because the fix is a design change rather than a patch: translate by error `code`, keep the server's text as the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)