### PR TITLE
UAT round 2: translated errors, shorter Friend Safari, no hidden achievements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 
 Six locales in `src/assets/i18n/*.json` (en, pt, es, fr, de, it), loaded over HTTP by `TranslateHttpLoader`. User-facing strings are **never** literals — data files store dotted keys (`items.potion.name`, `game.main.roulette.fishing.title`) that templates resolve with the `translate` pipe. Adding a string means adding it to all six files.
 
-**All six files hold an identical key set** (2,381 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
+**All six files hold an identical key set** (2,386 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
 
 ```bash
 node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"

--- a/src/app/services/achievement-service/achievement-catalog.spec.ts
+++ b/src/app/services/achievement-service/achievement-catalog.spec.ts
@@ -73,13 +73,4 @@ describe('the achievement catalog', () => {
     expect(progress.current).toBe(2);
   });
 
-  it('hides the achievements a player may never be able to earn', () => {
-    // Region-locked encounters: a player who only ever visits Johto cannot
-    // reach these, and three permanently locked rows read as broken.
-    for (const id of ['five_hundred_steps', 'friend_code', 'the_great_crater']) {
-      expect(ACHIEVEMENTS.find(a => a.id === id)!.hidden)
-        .withContext(`${id} is region-locked and should be hidden`)
-        .toBeTrue();
-    }
-  });
 });

--- a/src/app/services/achievement-service/achievement-catalog.ts
+++ b/src/app/services/achievement-service/achievement-catalog.ts
@@ -43,13 +43,6 @@ export type AchievementGroup =
 export interface Achievement {
   readonly id: string;
   readonly group: AchievementGroup;
-  /**
-   * Hidden until earned, so there is something to discover rather than a
-   * checklist to grind. Also used for the three region-locked encounters, which
-   * a player who never visits that region can never earn — a permanently
-   * locked visible row reads as broken.
-   */
-  readonly hidden?: boolean;
   readonly progress: (context: AchievementContext) => Progress;
 }
 
@@ -162,7 +155,7 @@ export const ACHIEVEMENTS: readonly Achievement[] = [
   { id: 'regional_champion', group: 'champion', progress: c => ({ current: championedRegions(c), target: 3 }) },
   { id: 'world_champion', group: 'champion', progress: c => ({ current: championedRegions(c), target: 9 }) },
   { id: 'full_house', group: 'champion', progress: counter('champion_with_six', 1) },
-  { id: 'pokemon_stadium', group: 'champion', hidden: true, progress: counter('champion_with_three_or_fewer', 1) },
+  { id: 'pokemon_stadium', group: 'champion', progress: counter('champion_with_three_or_fewer', 1) },
 
   // Rival.
   { id: 'smell_ya_later', group: 'rival', progress: counter('rival_battles_won', 1) },
@@ -186,9 +179,9 @@ export const ACHIEVEMENTS: readonly Achievement[] = [
   // Region-locked: Kanto, Kalos and Paldea only. Hidden, because a player who
   // never visits those regions would otherwise stare at three rows they cannot
   // earn and reasonably conclude something is broken.
-  { id: 'five_hundred_steps', group: 'encounters', hidden: true, progress: counter('safari_zone_visits', 1) },
-  { id: 'friend_code', group: 'encounters', hidden: true, progress: counter('friend_safari_visits', 1) },
-  { id: 'the_great_crater', group: 'encounters', hidden: true, progress: counter('area_zero_visits', 1) },
+  { id: 'five_hundred_steps', group: 'encounters', progress: counter('safari_zone_visits', 1) },
+  { id: 'friend_code', group: 'encounters', progress: counter('friend_safari_visits', 1) },
+  { id: 'the_great_crater', group: 'encounters', progress: counter('area_zero_visits', 1) },
   { id: 'a_fair_trade', group: 'encounters', progress: counter('trades_completed', 1) },
 
   // Badge dex.

--- a/src/app/services/auth-service/auth.service.ts
+++ b/src/app/services/auth-service/auth.service.ts
@@ -14,6 +14,22 @@ interface ApiErrorEnvelope {
 }
 
 /**
+ * API error codes this build can say something better than English about.
+ *
+ * `invalid_request` is deliberately generic here. The server sends a precise
+ * message for it -- which password rule was broken, say -- but the client
+ * checks those rules itself before submitting and says so in the player's own
+ * language, so reaching this is already an edge case.
+ */
+const ERROR_KEYS: Readonly<Record<string, string>> = {
+  unauthorized: 'account.error.credentials',
+  conflict: 'account.error.emailTaken',
+  rate_limited: 'account.error.rateLimited',
+  invalid_request: 'account.error.invalid',
+  internal: 'account.error.server',
+};
+
+/**
  * Accounts, and whether there is one.
  *
  * **The game works with no account, forever.** Nothing here may gate play: a
@@ -101,11 +117,39 @@ export class AuthService {
   }
 
   /**
-   * The message to show a player for a failed request.
+   * The translation key for a failed request, or `null` to show the server's
+   * own words.
    *
-   * Returns exactly what the API said. The signup and login endpoints answer
-   * "wrong password" and "no such account" identically **on purpose**, and a
-   * client that guesses a more specific message undoes that on the front end.
+   * Translating by **code** rather than by message is what lets this be
+   * localised at all. Showing the server's text verbatim was deliberate --
+   * login answers "wrong password" and "no such account" identically, and a
+   * client that guesses a more specific message undoes that -- but verbatim
+   * also meant English, in a game that ships in six languages. Mapping the
+   * code preserves the ambiguity exactly, because the *code* is identical in
+   * both cases too.
+   *
+   * A code this build does not recognise falls through to the server's text.
+   * The API deploys on its own schedule, and an English sentence that is
+   * precise beats a translated one that is wrong.
+   */
+  static errorKeyFor(error: unknown): string | null {
+    if (!(error instanceof HttpErrorResponse)) {
+      return null;
+    }
+
+    // No status at all is the network being unreachable, which the server
+    // never got to have an opinion about.
+    if (error.status === 0) {
+      return 'account.error.offline';
+    }
+
+    const code = (error.error as ApiErrorEnvelope | null)?.error?.code;
+    return code && Object.hasOwn(ERROR_KEYS, code) ? ERROR_KEYS[code] : null;
+  }
+
+  /**
+   * The message to show a player for a failed request, when no translation
+   * applies. Returns exactly what the API said.
    */
   static messageFor(error: unknown, fallback: string): string {
     if (error instanceof HttpErrorResponse) {

--- a/src/app/settings/account/account.component.spec.ts
+++ b/src/app/settings/account/account.component.spec.ts
@@ -194,21 +194,57 @@ describe('AccountComponent', () => {
 
   // Rewording here would undo the server's deliberate refusal to say which of
   // the two things was wrong.
-  it('shows the server\'s own message on failure', () => {
-    answerWhoAmI();
+  describe('error messages', () => {
 
-    component.email = 'ash@pallet.town';
-    component.password = 'pikachu-i-choose-you';
-    component.submit();
+    const failLogin = (body: object, status: number) => {
+      component.email = 'ash@pallet.town';
+      component.password = 'pikachu-i-choose-you';
+      component.submit();
+      http.expectOne(`${base}/auth/login`).flush(body, { status, statusText: 'Error' });
+      fixture.detectChanges();
+    };
 
-    http.expectOne(`${base}/auth/login`).flush(
-      { error: { code: 'unauthorized', message: 'That email and password do not match an account.' } },
-      { status: 401, statusText: 'Unauthorized' },
-    );
-    fixture.detectChanges();
+    it('translates a failure this build recognises', () => {
+      // Keyed on the error *code*, never on the server's text, which is
+      // English only. Five of the six locales would otherwise read English.
+      answerWhoAmI();
 
-    expect(component.error).toBe('That email and password do not match an account.');
-    expect(component.busy).toBeFalse();
+      failLogin({ error: { code: 'unauthorized', message: 'That email and password do not match an account.' } }, 401);
+
+      expect(component.error).toBe('account.error.credentials');
+      expect(component.busy).toBeFalse();
+    });
+
+    it('gives a wrong password and an unknown account the same message', () => {
+      // The API refuses to distinguish them. Translating by code keeps that
+      // true, because the code is identical in both cases.
+      answerWhoAmI();
+
+      failLogin({ error: { code: 'unauthorized', message: 'That email and password do not match an account.' } }, 401);
+      const wrongPassword = component.error;
+
+      failLogin({ error: { code: 'unauthorized', message: 'That email and password do not match an account.' } }, 401);
+
+      expect(component.error).toBe(wrongPassword);
+    });
+
+    it('falls back to the server\'s own words for a code it has never met', () => {
+      // The API deploys on its own schedule. An English sentence that is
+      // precise beats a translated one that is wrong.
+      answerWhoAmI();
+
+      failLogin({ error: { code: 'teapot', message: 'Something specific and new.' } }, 418);
+
+      expect(component.error).toBe('Something specific and new.');
+    });
+
+    it('says the server was unreachable rather than blaming the player', () => {
+      answerWhoAmI();
+
+      failLogin(new ProgressEvent('error'), 0);
+
+      expect(component.error).toBe('account.error.offline');
+    });
   });
 
   it('needs a password before it will delete anything', () => {

--- a/src/app/settings/account/account.component.ts
+++ b/src/app/settings/account/account.component.ts
@@ -189,11 +189,12 @@ export class AccountComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Runs a request, showing whatever the server said on failure.
+   * Runs a request, showing a translated message for any failure this build
+   * recognises and the server's own words for anything else.
    *
-   * Deliberately not translated and not reworded: signup and login answer
-   * "wrong password" and "no account" identically on purpose, and inventing a
-   * more specific message here would undo that.
+   * The translation is keyed on the API's error *code*, never on its text.
+   * Signup and login answer "wrong password" and "no account" identically on
+   * purpose, and their codes match too, so this cannot undo that.
    */
   private run<T>(request: Observable<T>, fallbackKey: string, onSuccess?: () => void): void {
     this.busy = true;
@@ -206,7 +207,12 @@ export class AccountComponent implements OnInit, OnDestroy {
       },
       error: (failure: unknown) => {
         this.busy = false;
-        this.error = AuthService.messageFor(failure, this.translate.instant(fallbackKey) as string);
+
+        const key = AuthService.errorKeyFor(failure);
+        this.error = key
+          ? (this.translate.instant(key) as string)
+          : AuthService.messageFor(failure, this.translate.instant(fallbackKey) as string);
+
         // The server's message says "Sign in instead"; this is the button
         // that does it, rather than making them find the tab and retype.
         this.emailTaken = failure instanceof HttpErrorResponse && failure.status === 409;

--- a/src/app/trainer-team/achievements/achievements.component.css
+++ b/src/app/trainer-team/achievements/achievements.component.css
@@ -55,12 +55,6 @@
   background: rgba(245, 197, 24, 0.14);
 }
 
-.achievement-row.concealed .achievement-name,
-.achievement-row.concealed .achievement-description {
-  opacity: 0.5;
-  font-style: italic;
-}
-
 .achievement-text {
   display: flex;
   flex-direction: column;

--- a/src/app/trainer-team/achievements/achievements.component.html
+++ b/src/app/trainer-team/achievements/achievements.component.html
@@ -32,25 +32,11 @@
         <h5 class="achievement-group-title">{{ groupLabelKey(group.group) | translate }}</h5>
 
         @for (achievement of group.achievements; track achievement.id) {
-          <div class="achievement-row"
-               [class.unlocked]="isUnlocked(achievement)"
-               [class.concealed]="isConcealed(achievement)">
+          <div class="achievement-row" [class.unlocked]="isUnlocked(achievement)">
 
             <div class="achievement-text">
-              <span class="achievement-name">
-                @if (isConcealed(achievement)) {
-                  ???
-                } @else {
-                  {{ nameKey(achievement) | translate }}
-                }
-              </span>
-              <span class="achievement-description">
-                @if (isConcealed(achievement)) {
-                  {{ 'achievementsScreen.hidden' | translate }}
-                } @else {
-                  {{ descriptionKey(achievement) | translate }}
-                }
-              </span>
+              <span class="achievement-name">{{ nameKey(achievement) | translate }}</span>
+              <span class="achievement-description">{{ descriptionKey(achievement) | translate }}</span>
             </div>
 
             <div class="achievement-progress">
@@ -64,11 +50,9 @@
                      aria-valuemax="100">
                   <div class="progress-fill" [style.width.%]="percentFor(achievement)"></div>
                 </div>
-                @if (!isConcealed(achievement)) {
-                  <span class="progress-numbers">
-                    {{ progressFor(achievement).current }}/{{ progressFor(achievement).target }}
-                  </span>
-                }
+                <span class="progress-numbers">
+                  {{ progressFor(achievement).current }}/{{ progressFor(achievement).target }}
+                </span>
               }
             </div>
           </div>

--- a/src/app/trainer-team/achievements/achievements.component.spec.ts
+++ b/src/app/trainer-team/achievements/achievements.component.spec.ts
@@ -73,22 +73,6 @@ describe('AchievementsComponent', () => {
     expect(component.percentFor(smell)).toBe(100);
   });
 
-  it('conceals a hidden achievement until it is earned', () => {
-    const stadium = ACHIEVEMENTS.find(a => a.id === 'pokemon_stadium')!;
-    expect(component.isConcealed(stadium)).toBeTrue();
-
-    TestBed.inject(StatsService).recordChampion(1, 3);
-    fixture.detectChanges();
-
-    expect(component.isConcealed(stadium))
-      .withContext('once earned there is nothing left to hide')
-      .toBeFalse();
-  });
-
-  it('does not conceal an ordinary locked achievement', () => {
-    expect(component.isConcealed(ACHIEVEMENTS.find(a => a.id === 'veteran')!)).toBeFalse();
-  });
-
   it('reports lifetime totals', () => {
     TestBed.inject(StatsService).increment('spins_total', 430);
     fixture.detectChanges();

--- a/src/app/trainer-team/achievements/achievements.component.ts
+++ b/src/app/trainer-team/achievements/achievements.component.ts
@@ -95,15 +95,6 @@ export class AchievementsComponent implements OnInit, OnDestroy {
     return achievement.id in this.unlocks;
   }
 
-  /**
-   * Hidden achievements stay nameless until earned, so there is something to
-   * discover — and so the three region-locked ones do not read as broken to
-   * someone who never visits those regions.
-   */
-  isConcealed(achievement: Achievement): boolean {
-    return achievement.hidden === true && !this.isUnlocked(achievement);
-  }
-
   nameKey(achievement: Achievement): string {
     return achievementNameKey(achievement.id);
   }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -258,7 +258,7 @@
             "findFossil": "Finde ein Fossil",
             "battleRival": "Rivalen-Kampf",
             "safariZone": "Besuche die Safari-Zone",
-            "friendSafari": "Betritt eine Freundes-Safari",
+            "friendSafari": "Freundes-Safari",
             "areaZero": "Erkunde Zone Null"
           }
         },
@@ -2836,7 +2836,6 @@
     "button": "Erfolge",
     "title": "Erfolge",
     "unlocked": "Erfolg freigeschaltet",
-    "hidden": "Noch ein Geheimnis.",
     "group": {
       "collection": "Sammlung",
       "shiny": "Schillernd",
@@ -3076,7 +3075,13 @@
     "cancel": "Abbrechen",
     "deleteWarning": "Damit werden dein Konto und alle Inhalte endgültig gelöscht. Gib zur Bestätigung dein Passwort ein.",
     "error": {
-      "generic": "Das hat nicht geklappt. Bitte versuche es erneut."
+      "generic": "Das hat nicht geklappt. Bitte versuche es erneut.",
+      "credentials": "Diese E-Mail und dieses Passwort gehören zu keinem Konto.",
+      "emailTaken": "Es gibt bereits ein Konto mit dieser E-Mail. Melde dich stattdessen an.",
+      "rateLimited": "Zu viele Versuche. Warte einen Moment und versuche es erneut.",
+      "invalid": "Überprüfe deine Eingaben und versuche es erneut.",
+      "server": "Bei uns ist etwas schiefgelaufen. Versuche es erneut.",
+      "offline": "Der Server war nicht erreichbar. Prüfe deine Verbindung und versuche es erneut."
     },
     "sync": {
       "off": "Keine Synchronisierung.",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -258,7 +258,7 @@
             "findFossil": "Find a Fossil",
             "battleRival": "Battle Rival",
             "safariZone": "Visit the Safari Zone",
-            "friendSafari": "Enter a Friend Safari",
+            "friendSafari": "Friend Safari",
             "areaZero": "Explore Area Zero"
           }
         },
@@ -2836,7 +2836,6 @@
     "button": "Achievements",
     "title": "Achievements",
     "unlocked": "Achievement unlocked",
-    "hidden": "A secret, for now.",
     "group": {
       "collection": "Collection",
       "shiny": "Shiny",
@@ -3076,7 +3075,13 @@
     "cancel": "Cancel",
     "deleteWarning": "This deletes your account and everything in it, permanently. Enter your password to confirm.",
     "error": {
-      "generic": "That did not work. Please try again."
+      "generic": "That did not work. Please try again.",
+      "credentials": "That email and password do not match an account.",
+      "emailTaken": "An account with that email already exists. Sign in instead.",
+      "rateLimited": "Too many attempts. Please wait a moment and try again.",
+      "invalid": "Please check what you typed and try again.",
+      "server": "Something went wrong on our end. Please try again.",
+      "offline": "Could not reach the server. Check your connection and try again."
     },
     "sync": {
       "off": "Not syncing.",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -258,12 +258,12 @@
             "findFossil": "Encontrar un fósil",
             "battleRival": "Combate contra el Rival",
             "safariZone": "Visitar la Zona Safari",
-            "friendSafari": "Entrar en una Safari Amigo",
+            "friendSafari": "Safari Amistad",
             "areaZero": "Explorar el Área Cero"
           }
         },
         "friendSafari": {
-          "which": "¿Qué Safari Amigo?",
+          "which": "¿Qué Safari Amistad?",
           "catch": "¿Qué Pokémon vas a capturar?"
         },
         "safariZone": {
@@ -2836,7 +2836,6 @@
     "button": "Logros",
     "title": "Logros",
     "unlocked": "Logro desbloqueado",
-    "hidden": "Un secreto, por ahora.",
     "group": {
       "collection": "Colección",
       "shiny": "Shiny",
@@ -3002,7 +3001,7 @@
     },
     "friend_code": {
       "name": "Código de Amigo",
-      "description": "Visita la Zona Safari Amigo."
+      "description": "Visita el Safari Amistad."
     },
     "the_great_crater": {
       "name": "El Gran Cráter",
@@ -3076,7 +3075,13 @@
     "cancel": "Cancelar",
     "deleteWarning": "Esto elimina tu cuenta y todo su contenido, de forma permanente. Escribe tu contraseña para confirmar.",
     "error": {
-      "generic": "No ha funcionado. Inténtalo de nuevo."
+      "generic": "No ha funcionado. Inténtalo de nuevo.",
+      "credentials": "Ese correo y contraseña no coinciden con ninguna cuenta.",
+      "emailTaken": "Ya existe una cuenta con ese correo. Inicia sesión.",
+      "rateLimited": "Demasiados intentos. Espera un momento e inténtalo de nuevo.",
+      "invalid": "Revisa lo que escribiste e inténtalo de nuevo.",
+      "server": "Algo salió mal de nuestro lado. Inténtalo de nuevo.",
+      "offline": "No se pudo contactar con el servidor. Comprueba tu conexión e inténtalo de nuevo."
     },
     "sync": {
       "off": "Sin sincronizar.",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -258,12 +258,12 @@
             "findFossil": "Trouver un fossile",
             "battleRival": "Combattre le rival",
             "safariZone": "Visiter le Parc Safari",
-            "friendSafari": "Entrer dans une Safari des Amis",
+            "friendSafari": "Safari des Amis",
             "areaZero": "Explorer la Zone Zéro"
           }
         },
         "friendSafari": {
-          "which": "Quelle Safari des Amis ?",
+          "which": "Quel Safari des Amis ?",
           "catch": "Quel Pokémon allez-vous capturer ?"
         },
         "safariZone": {
@@ -2836,7 +2836,6 @@
     "button": "Succès",
     "title": "Succès",
     "unlocked": "Succès débloqué",
-    "hidden": "Un secret, pour l’instant.",
     "group": {
       "collection": "Collection",
       "shiny": "Chromatiques",
@@ -3076,7 +3075,13 @@
     "cancel": "Annuler",
     "deleteWarning": "Ceci supprime votre compte et tout son contenu, définitivement. Saisissez votre mot de passe pour confirmer.",
     "error": {
-      "generic": "Cela n'a pas fonctionné. Veuillez réessayer."
+      "generic": "Cela n'a pas fonctionné. Veuillez réessayer.",
+      "credentials": "Cet e-mail et ce mot de passe ne correspondent à aucun compte.",
+      "emailTaken": "Un compte existe déjà avec cet e-mail. Connectez-vous.",
+      "rateLimited": "Trop de tentatives. Patientez un instant et réessayez.",
+      "invalid": "Vérifiez ce que vous avez saisi et réessayez.",
+      "server": "Un problème est survenu de notre côté. Réessayez.",
+      "offline": "Impossible de joindre le serveur. Vérifiez votre connexion et réessayez."
     },
     "sync": {
       "off": "Pas de synchronisation.",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -258,7 +258,7 @@
             "findFossil": "Trova un fossile",
             "battleRival": "Lotta contro il rivale",
             "safariZone": "Visita la Zona Safari",
-            "friendSafari": "Entra in un Safari degli Amici",
+            "friendSafari": "Safari degli Amici",
             "areaZero": "Esplora Area Zero"
           }
         },
@@ -2836,7 +2836,6 @@
     "button": "Obiettivi",
     "title": "Obiettivi",
     "unlocked": "Obiettivo sbloccato",
-    "hidden": "Un segreto, per ora.",
     "group": {
       "collection": "Collezione",
       "shiny": "Shiny",
@@ -3076,7 +3075,13 @@
     "cancel": "Annulla",
     "deleteWarning": "Questo elimina il tuo account e tutto il suo contenuto, definitivamente. Inserisci la password per confermare.",
     "error": {
-      "generic": "Non ha funzionato. Riprova."
+      "generic": "Non ha funzionato. Riprova.",
+      "credentials": "Questa email e questa password non corrispondono a nessun account.",
+      "emailTaken": "Esiste già un account con questa email. Accedi invece.",
+      "rateLimited": "Troppi tentativi. Aspetta un momento e riprova.",
+      "invalid": "Controlla quello che hai scritto e riprova.",
+      "server": "Qualcosa è andato storto da parte nostra. Riprova.",
+      "offline": "Impossibile raggiungere il server. Controlla la connessione e riprova."
     },
     "sync": {
       "off": "Nessuna sincronizzazione.",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -258,12 +258,12 @@
             "findFossil": "Encontrar um Fóssil",
             "battleRival": "Batalha contra o Rival",
             "safariZone": "Visitar a Zona Safári",
-            "friendSafari": "Entrar em um Safári dos Amigos",
+            "friendSafari": "Friend Safari",
             "areaZero": "Explorar a Área Zero"
           }
         },
         "friendSafari": {
-          "which": "Qual Safári dos Amigos?",
+          "which": "Qual Friend Safari?",
           "catch": "Qual Pokémon você vai capturar?"
         },
         "safariZone": {
@@ -2836,7 +2836,6 @@
     "button": "Conquistas",
     "title": "Conquistas",
     "unlocked": "Conquista desbloqueada",
-    "hidden": "Um segredo, por enquanto.",
     "group": {
       "collection": "Coleção",
       "shiny": "Shiny",
@@ -3002,7 +3001,7 @@
     },
     "friend_code": {
       "name": "Código de Amigo",
-      "description": "Visite o Safári dos Amigos."
+      "description": "Visite o Friend Safari."
     },
     "the_great_crater": {
       "name": "A Grande Cratera",
@@ -3076,7 +3075,13 @@
     "cancel": "Cancelar",
     "deleteWarning": "Isso exclui sua conta e tudo nela, permanentemente. Digite sua senha para confirmar.",
     "error": {
-      "generic": "Não funcionou. Tente novamente."
+      "generic": "Não funcionou. Tente novamente.",
+      "credentials": "Esse email e senha não correspondem a nenhuma conta.",
+      "emailTaken": "Já existe uma conta com esse email. Entre nela.",
+      "rateLimited": "Muitas tentativas. Espere um momento e tente de novo.",
+      "invalid": "Confira o que você digitou e tente de novo.",
+      "server": "Algo deu errado do nosso lado. Tente de novo.",
+      "offline": "Não foi possível falar com o servidor. Verifique sua conexão e tente de novo."
     },
     "sync": {
       "off": "Sem sincronização.",


### PR DESCRIPTION
**Stacked on #74** — its base is `fix/uat-round-1`, so this diff shows only the new work. Merging #74 retargets this at `main` automatically. Order: [backend #37](https://github.com/zeroxm/pokemon-roulette-backend/pull/37) → #74 → this.

**524/524 tests**, i18n parity at **2,386**.

## Account errors are translated — keyed on the code, not the message

This is finding 6. Showing the server's message verbatim was deliberate: login answers "wrong password" and "no such account" identically, and a client that reworded them would undo that. But verbatim also meant **English**, and UAT caught the result — "An account with that email already exists. Sign in instead." sitting next to a button reading "Entrar".

Keying on the error **code** preserves the ambiguity exactly, because the code is identical in both cases too. There's a test asserting a wrong password and an unknown account still produce the same message.

Two deliberate details:

- **An unknown code still falls through to the server's own words.** The API deploys on its own schedule, and an English sentence that is *precise* beats a translated one that is *wrong*.
- **`invalid_request` maps to something generic.** The server sends a specific message — which password rule broke — but the client checks those rules itself, in the player's language, before submitting. Reaching it means the client's own validation was bypassed.

Also added an offline message, for `status === 0`, where the server never got to have an opinion.

## Friend Safari is now just its name

"Enter a Friend Safari" was too long for a wheel slice, and the localisations were worse — Portuguese read "Entrar em um Safári dos Amigos".

| | was | now |
|---|---|---|
| en | Enter a Friend Safari | **Friend Safari** |
| pt | Entrar em um Safári dos Amigos | **Friend Safari** |
| es | Entrar en una Safari Amigo | **Safari Amistad** |
| fr | Entrer dans une Safari des Amis | **Safari des Amis** |
| de | Betritt eine Freundes-Safari | **Freundes-Safari** |
| it | Entra in un Safari degli Amici | **Safari degli Amici** |

The non-English names are the official Pokémon X/Y localisations. Spanish was also **wrong** before — "Safari Amigo" is not the official name; it's "Safari Amistad".

I applied the same name to the two follow-on strings ("Which …?" and the achievement description), so the wheel and the screen after it agree. A slice reading "Friend Safari" leading to a screen headed "Qual Safári dos Amigos?" would just look like a different feature.

## Nothing is hidden any more

Four achievements concealed their name and description until earned. Your call, and it removed real machinery rather than just a flag: the interface field, `isConcealed`, both template branches, the `???` placeholder, the `achievementsScreen.hidden` string in all six locales, and the italic styling.

Worth noting the original reason, now overridden: three of the four are region-locked (Safari Zone, Friend Safari, Area Zero), and the thinking was that a permanently locked visible row reads as broken to someone who never visits those regions. With them visible, a Johto-only player sees three rows at 0/1 they can't currently explain. That's a fair trade for not hiding things — and arguably better, since it tells them the content exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)