### PR TITLE
Fix: mega evolution transformed every copy of a species

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ npm run deploy                                   # gh-pages, base-href /pokemon-
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
 
-**Green baseline:** build passes, **524/524 tests pass**. Any change must leave both green.
+**Green baseline:** build passes, **525/525 tests pass**. Any change must leave both green.
 
 ### Local environment gotchas
 

--- a/src/app/items/items.component.ts
+++ b/src/app/items/items.component.ts
@@ -8,6 +8,7 @@ import { TrainerService } from '../services/trainer-service/trainer.service';
 import {TranslatePipe, TranslateService} from '@ngx-translate/core';
 import { isMegaStoneItemName } from '../services/items-service/item-names';
 import { ImageFallbackDirective } from '../directives/image-fallback.directive';
+import { MegaStoneActivation } from '../services/mega-stone-service/mega-stone.service';
 
 @Component({
   selector: 'app-items',
@@ -33,7 +34,7 @@ export class ItemsComponent implements OnInit, OnDestroy {
   /** Slot indices for the item grid. The bag renders a fixed twelve, filled or not. */
   readonly slots = Array.from({ length: 12 }, (_, index) => index);
   @Output() rareCandyInterrupt = new EventEmitter<ItemItem>();
-  @Output() megaStoneInterrupt = new EventEmitter<ItemItem>();
+  @Output() megaStoneInterrupt = new EventEmitter<MegaStoneActivation>();
 
   darkMode!: Observable<boolean>;
   private itemsSubscription!: Subscription;
@@ -53,7 +54,7 @@ export class ItemsComponent implements OnInit, OnDestroy {
       if (item.name === 'rare-candy') {
         this.rareCandyInterrupt.emit(item);
       } else if (isMegaStoneItemName(item.name)) {
-        this.megaStoneInterrupt.emit(item);
+        this.megaStoneInterrupt.emit({ stone: item });
       }
     }
   }

--- a/src/app/main-game/main-game.component.ts
+++ b/src/app/main-game/main-game.component.ts
@@ -17,7 +17,7 @@ import { LanguageSelectorComponent } from './language-selector/language-selector
 import { RouletteContainerComponent } from './roulette-container/roulette-container.component';
 import { SettingsButtonComponent } from '../settings-button/settings-button.component';
 import { RareCandyService } from '../services/rare-candy-service/rare-candy.service';
-import { MegaStoneService } from '../services/mega-stone-service/mega-stone.service';
+import { MegaStoneActivation, MegaStoneService } from '../services/mega-stone-service/mega-stone.service';
 
 @Component({
   selector: 'app-main-game',
@@ -77,12 +77,12 @@ export class MainGameComponent implements OnInit {
     this.rareCandyService.triggerRareCandyEvolution(rareCandy);
   }
 
-  megaStoneInterrupt(megaStone: ItemItem): void {
+  megaStoneInterrupt(activation: MegaStoneActivation): void {
     if (this.wheelSpinning) {
       return;
     }
 
-    this.megaStoneService.triggerMegaStoneActivation(megaStone);
+    this.megaStoneService.triggerMegaStoneActivation(activation);
   }
 
   resetGame(): void {

--- a/src/app/main-game/roulette-container/roulette-container.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.spec.ts
@@ -205,7 +205,7 @@ describe('RouletteContainerComponent', () => {
     it('records the win against the base Pokémon, not the mega form', () => {
       trainerService.addToTeam(pokemonService.getPokemonById(CHARIZARD)!);
       giveStone('charizardite-x');
-      trainerService.forceMegaActivation(CHARIZARD, 'charizardite-x' as any);
+      trainerService.forceMegaActivation(trainerService.getTeam()[0], 'charizardite-x' as any);
       expect(trainerService.getTeam()[0].pokemonId)
         .withContext('the Pokémon must actually be mega-evolved when the champion falls')
         .toBe(MEGA_CHARIZARD_X);

--- a/src/app/main-game/roulette-container/roulette-container.component.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.ts
@@ -56,7 +56,7 @@ import { EndGameComponent } from "../end-game/end-game.component";
 import { GameOverComponent } from "../game-over/game-over.component";
 import { ModalQueueService } from '../../services/modal-queue-service/modal-queue.service';
 import { PokemonFormsService } from '../../services/pokemon-forms-service/pokemon-forms.service';
-import { MegaStoneService } from '../../services/mega-stone-service/mega-stone.service';
+import { MegaStoneActivation, MegaStoneService } from '../../services/mega-stone-service/mega-stone.service';
 import { megaStoneNamesForBaseId, pokemonMegaForms } from '../../services/trainer-service/pokemon-mega-forms';
 import { MegaEvolutionAnimationModalComponent } from './roulettes/mega-evolution-animation-modal/mega-evolution-animation-modal.component';
 import { SelectFromItemListRouletteComponent } from './roulettes/select-from-item-list-roulette/select-from-item-list-roulette.component';
@@ -159,8 +159,8 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
       this.handleRareCandyEvolution(rareCandy);
     });
 
-    this.megaStoneSubscription = this.megaStoneService.megaStoneTrigger$.subscribe((megaStone) => {
-      this.handleMegaStoneActivation(megaStone);
+    this.megaStoneSubscription = this.megaStoneService.megaStoneTrigger$.subscribe((activation) => {
+      this.handleMegaStoneActivation(activation);
     });
   }
 
@@ -847,7 +847,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
   }
 
 
-  private handleMegaStoneActivation(megaStone: ItemItem): void {
+  private handleMegaStoneActivation({ stone: megaStone, pokemon }: MegaStoneActivation): void {
     if (!this.isBattleState(this.currentGameState)) {
       return;
     }
@@ -867,8 +867,11 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const matchingPokemon = this.getPokemonMatchingMegaStone(megaStone.name);
-    if (matchingPokemon.length === 0) {
+    // The team member the player actually tapped, when there was one. Falling
+    // back to the first match is only for a stone tapped in the bag, where
+    // nothing was pointed at.
+    const target = pokemon ?? this.getPokemonMatchingMegaStone(megaStone.name)[0];
+    if (!target) {
       return;
     }
 
@@ -882,7 +885,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
       ]);
     }
 
-    this.activateMegaEvolutionForPokemon(matchingPokemon[0].pokemonId, megaStone.name);
+    this.activateMegaEvolutionForPokemon(target, megaStone.name);
   }
 
   private getPokemonMatchingMegaStone(stoneName: MegaStoneItemName): PokemonItem[] {
@@ -903,9 +906,10 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
     return matching;
   }
 
-  private activateMegaEvolutionForPokemon(basePokemonId: number, stoneName?: MegaStoneItemName): void {
+  private activateMegaEvolutionForPokemon(target: PokemonItem, stoneName?: MegaStoneItemName): void {
+    const basePokemonId = target.pokemonId;
     this.trainerService.setMegaBattlePokemon(basePokemonId);
-    this.trainerService.forceMegaActivation(basePokemonId, stoneName);
+    this.trainerService.forceMegaActivation(target, stoneName);
     this.pokedexService.markMega(basePokemonId);
     void this.showMegaEvolutionAnimation(basePokemonId, stoneName);
   }

--- a/src/app/services/form-rule-service/form-rule.service.ts
+++ b/src/app/services/form-rule-service/form-rule.service.ts
@@ -109,15 +109,29 @@ export class FormRuleService {
     return reverted;
   }
 
-  /** Applies one rule immediately — used when a stone is tapped mid-battle. */
-  forceApply(ruleId: string, team: PokemonItem[], stored: PokemonItem[], heldItems: readonly ItemName[]): boolean {
+  /**
+   * Applies one rule immediately — used when a stone is tapped mid-battle.
+   *
+   * `target` limits it to a single Pokémon, by identity. Without it, a player
+   * carrying two Kangaskhan and tapping one stone mega evolved **both**: the
+   * rule matches on species, and every member of the collection that matches
+   * is transformed. That is right for a rule that fires on battle start and
+   * wrong for one a player triggers by pointing at something.
+   */
+  forceApply(
+    ruleId: string,
+    team: PokemonItem[],
+    stored: PokemonItem[],
+    heldItems: readonly ItemName[],
+    target?: PokemonItem,
+  ): boolean {
     const rule = this.rulesById.get(ruleId);
     if (!rule) {
       return false;
     }
     // A forced application still has to be undone at battle end.
     this.formsApplied = true;
-    return this.applyRule(rule, team, stored, heldItems);
+    return this.applyRule(rule, team, stored, heldItems, target);
   }
 
   /** True when any collection currently holds a non-base form of the given rule. */
@@ -140,12 +154,19 @@ export class FormRuleService {
 
   private applyRule(
     rule: FormRule, team: PokemonItem[], stored: PokemonItem[], heldItems: readonly ItemName[],
+    only?: PokemonItem,
   ): boolean {
     let changed = false;
 
     for (const collection of this.collectionsFor(rule, team, stored)) {
       for (let i = 0; i < collection.length; i++) {
         const current = collection[i];
+        // Identity, not species: two of the same Pokémon are the same species
+        // and the same stone, and only one of them was pointed at.
+        if (only && current !== only) {
+          continue;
+        }
+
         const target = this.pickTarget(rule, current, heldItems);
         if (!target || target.pokemonId === current.pokemonId) {
           continue;

--- a/src/app/services/mega-stone-service/mega-stone.service.ts
+++ b/src/app/services/mega-stone-service/mega-stone.service.ts
@@ -1,18 +1,33 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 import { ItemItem } from '../../interfaces/item-item';
+import { PokemonItem } from '../../interfaces/pokemon-item';
+
+/**
+ * A request to mega evolve.
+ *
+ * `pokemon` is the exact team member whose stone was tapped, and it is the
+ * reason this is an object rather than the bare item: two of the same species
+ * hold the same stone, so the stone alone cannot say which one the player
+ * meant. It is absent when the stone was tapped in the bag, where there is
+ * nothing to point at.
+ */
+export interface MegaStoneActivation {
+  readonly stone: ItemItem;
+  readonly pokemon?: PokemonItem;
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class MegaStoneService {
-  private megaStoneTriggerSubject = new Subject<ItemItem>();
+  private megaStoneTriggerSubject = new Subject<MegaStoneActivation>();
 
   get megaStoneTrigger$() {
     return this.megaStoneTriggerSubject.asObservable();
   }
 
-  triggerMegaStoneActivation(megaStone: ItemItem): void {
-    this.megaStoneTriggerSubject.next(megaStone);
+  triggerMegaStoneActivation(activation: MegaStoneActivation): void {
+    this.megaStoneTriggerSubject.next(activation);
   }
 }

--- a/src/app/services/trainer-service/trainer.service.spec.ts
+++ b/src/app/services/trainer-service/trainer.service.spec.ts
@@ -283,7 +283,7 @@ describe('TrainerService', () => {
     });
 
     it('gives Mega Y when Charizardite Y is the stone tapped', () => {
-      service.forceMegaActivation(CHARIZARD, 'charizardite-y' as any);
+      service.forceMegaActivation(service.trainerTeam[0], 'charizardite-y' as any);
 
       expect(service.trainerTeam[0].pokemonId)
         .withContext('holding X as well must not override the stone the player tapped')
@@ -291,13 +291,28 @@ describe('TrainerService', () => {
     });
 
     it('gives Mega X when Charizardite X is the stone tapped', () => {
-      service.forceMegaActivation(CHARIZARD, 'charizardite-x' as any);
+      service.forceMegaActivation(service.trainerTeam[0], 'charizardite-x' as any);
 
       expect(service.trainerTeam[0].pokemonId).toBe(MEGA_X);
     });
 
+    it('mega evolves only the Pokémon that was tapped, not every copy of it', () => {
+      // Reported from a real run: two Kangaskhan on the team, tap one stone,
+      // both transformed. The rule matches on species, so every member of the
+      // collection matched -- right for a rule that fires on battle start,
+      // wrong for one the player triggers by pointing at something.
+      service.trainerTeam = [structuredClone(charizard), structuredClone(charizard)];
+
+      service.forceMegaActivation(service.trainerTeam[1], 'charizardite-x' as any);
+
+      expect(service.trainerTeam[1].pokemonId).toBe(MEGA_X);
+      expect(service.trainerTeam[0].pokemonId)
+        .withContext('the other one was never pointed at')
+        .toBe(CHARIZARD);
+    });
+
     it('falls back to any held stone when none was named', () => {
-      service.forceMegaActivation(CHARIZARD);
+      service.forceMegaActivation(service.trainerTeam[0]);
 
       expect([MEGA_X, MEGA_Y]).toContain(service.trainerTeam[0].pokemonId);
     });

--- a/src/app/services/trainer-service/trainer.service.ts
+++ b/src/app/services/trainer-service/trainer.service.ts
@@ -321,14 +321,17 @@ export class TrainerService implements OnDestroy {
   }
 
   /** Applies mega evolution immediately for the selected base Pokémon during a battle. */
-  forceMegaActivation(baseId: number, stoneName?: MegaStoneItemName): void {
+  forceMegaActivation(target: PokemonItem, stoneName?: MegaStoneItemName): void {
+    const baseId = target.pokemonId;
     this.megaBattleBaseId = baseId;
 
     // Offer *only* the tapped stone. The rule scans its own forms in order rather than the list it
     // is handed, so passing the others would let forms[0] win whichever stone the player tapped.
     const heldItems = stoneName && this.hasItem(stoneName) ? [stoneName] : this.heldItemNames();
+    // The tapped Pokémon, by identity. Passing only the species mega evolved
+    // every copy of it on the team.
     const changed = this.formRuleService.forceApply(
-      `mega:${baseId}`, this.trainerTeam, this.storedPokemon, heldItems,
+      `mega:${baseId}`, this.trainerTeam, this.storedPokemon, heldItems, target,
     );
 
     if (changed) {

--- a/src/app/trainer-team/trainer-team.component.ts
+++ b/src/app/trainer-team/trainer-team.component.ts
@@ -12,8 +12,8 @@ import { PokedexComponent } from "./pokedex/pokedex.component";
 import { BadgeDexComponent } from "./badge-dex/badge-dex.component";
 import { AchievementsComponent } from "./achievements/achievements.component";
 import {TranslatePipe} from '@ngx-translate/core';
-import { ItemItem } from '../interfaces/item-item';
 import { ImageFallbackDirective } from '../directives/image-fallback.directive';
+import { MegaStoneActivation } from '../services/mega-stone-service/mega-stone.service';
 
 @Component({
   selector: 'app-trainer-team',
@@ -36,7 +36,7 @@ export class TrainerTeamComponent implements OnInit, OnDestroy {
   trainerBadges!: Badge[];
 
   darkMode!: Observable<boolean>;
-  @Output() megaStoneInterrupt = new EventEmitter<ItemItem>();
+  @Output() megaStoneInterrupt = new EventEmitter<MegaStoneActivation>();
 
   private trainerSubscription!: Subscription;
   private teamSubscription!: Subscription;
@@ -86,7 +86,7 @@ export class TrainerTeamComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.megaStoneInterrupt.emit(megaStone);
+    this.megaStoneInterrupt.emit({ stone: megaStone, pokemon });
   }
 
   private getHeldMegaStoneItem(pokemon: PokemonItem | undefined) {


### PR DESCRIPTION
Your Kangaskhan bug. **525/525 tests.**

Stacked on #75 (which is stacked on #74) to avoid conflicts — merge order is [backend #37](https://github.com/zeroxm/pokemon-roulette-backend/pull/37) → #74 → #75 → this.

## What was wrong

The entire mega path was keyed on a **species id**. `FormRule` matches on species, and `applyRule` transforms *every* member of the collection that matches — which is correct for a rule that fires automatically at battle start, and wrong for one the player triggers by pointing at something.

The most telling part: **the click already knew which team slot it came from and threw that away**, emitting only the stone. From there, nothing downstream could have known which Kangaskhan you meant.

It's been there since form rules were unified — the table made every mechanic share one apply loop, and that loop was written for the automatic case.

## The fix

The tapped Pokémon now travels with the trigger. `MegaStoneActivation` carries the stone and, when something was pointed at, the Pokémon itself. The bag sends no Pokémon — there's nothing there to point at — and falls back to the first match.

`forceApply` takes an optional target and compares by **identity**, not by species or index. Two of the same Pokémon are the same species holding the same stone; identity is the only thing that distinguishes them.

## The test was checked against the unfixed code

With the identity guard disabled it fails, and passes with it. A regression test nobody has watched fail is a test that might assert nothing.

```
TrainerService mega evolution ... only the Pokémon that was tapped ... FAILED
TOTAL: 1 FAILED, 524 SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)