### PR TITLE
One Rotom Phone button for the Pokédex, badges and achievements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 
 Six locales in `src/assets/i18n/*.json` (en, pt, es, fr, de, it), loaded over HTTP by `TranslateHttpLoader`. User-facing strings are **never** literals — data files store dotted keys (`items.potion.name`, `game.main.roulette.fishing.title`) that templates resolve with the `translate` pipe. Adding a string means adding it to all six files.
 
-**All six files hold an identical key set** (2,381 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
+**All six files hold an identical key set** (2,386 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
 
 ```bash
 node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ npm run deploy                                   # gh-pages, base-href /pokemon-
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
 
-**Green baseline:** build passes, **524/524 tests pass**. Any change must leave both green.
+**Green baseline:** build passes, **525/525 tests pass**. Any change must leave both green.
 
 ### Local environment gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ npm run deploy                                   # gh-pages, base-href /pokemon-
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
 
-**Green baseline:** build passes, **525/525 tests pass**. Any change must leave both green.
+**Green baseline:** build passes, **524/524 tests pass**. Any change must leave both green.
 
 ### Local environment gotchas
 
@@ -219,7 +219,7 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 
 Six locales in `src/assets/i18n/*.json` (en, pt, es, fr, de, it), loaded over HTTP by `TranslateHttpLoader`. User-facing strings are **never** literals — data files store dotted keys (`items.potion.name`, `game.main.roulette.fishing.title`) that templates resolve with the `translate` pipe. Adding a string means adding it to all six files.
 
-**All six files hold an identical key set** (2,386 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
+**All six files hold an identical key set** (2,385 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
 
 ```bash
 node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ npm run deploy                                   # gh-pages, base-href /pokemon-
 
 CI (`.github/workflows/node.js.yml`) runs `npm ci`, `npm audit --omit=dev --audit-level=high`, `npm run build`, and the headless test command on every push/PR to `main`. The audit gate is scoped to production dependencies, but the tree is currently clean either way — **`npm audit` reports 0 vulnerabilities with dev dependencies included**. Keep it that way: the last 7 all arrived through a single package (see *Toolchain* below). There is no lint step; `noUnusedLocals`/`noUnusedParameters` cover that class of problem.
 
-**Green baseline:** build passes, **519/519 tests pass**. Any change must leave both green.
+**Green baseline:** build passes, **524/524 tests pass**. Any change must leave both green.
 
 ### Local environment gotchas
 
@@ -219,7 +219,7 @@ triggers **Ash-Greninja** off the same method, which is why `usePotion` lives in
 
 Six locales in `src/assets/i18n/*.json` (en, pt, es, fr, de, it), loaded over HTTP by `TranslateHttpLoader`. User-facing strings are **never** literals — data files store dotted keys (`items.potion.name`, `game.main.roulette.fishing.title`) that templates resolve with the `translate` pipe. Adding a string means adding it to all six files.
 
-**All six files hold an identical key set** (2,379 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
+**All six files hold an identical key set** (2,381 keys). ngx-translate renders the raw key on a miss, so a key present in code but absent from a locale ships as literal `badges.bug_paldea` text to users. Verify parity after any i18n change:
 
 ```bash
 node -e "const p=(o,x='')=>Object.entries(o).flatMap(([k,v])=>typeof v==='object'&&v?p(v,x+k+'.'):[x+k]);const b=p(require('./src/assets/i18n/en.json')).sort();for(const l of ['pt','es','fr','de','it']){const o=p(require('./src/assets/i18n/'+l+'.json')).sort();console.log(l,b.filter(k=>!o.includes(k)).length||o.filter(k=>!b.includes(k)).length?'DIVERGENT':'ok')}"

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -16,7 +16,8 @@ import {
   bootstrapPcDisplayHorizontal,
   bootstrapPeopleFill,
   bootstrapShare,
-  bootstrapBook
+  bootstrapBook,
+  bootstrapPhone
 } from '@ng-icons/bootstrap-icons';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { provideTranslateService } from '@ngx-translate/core';
@@ -38,7 +39,8 @@ export const appConfig: ApplicationConfig = {
         bootstrapPeopleFill,
         bootstrapShare,
         bootstrapMap,
-        bootstrapBook
+        bootstrapBook,
+        bootstrapPhone
        }),
     provideHttpClient(withXhr()),
     provideZoneChangeDetection({ eventCoalescing: true }),

--- a/src/app/items/items.component.ts
+++ b/src/app/items/items.component.ts
@@ -8,6 +8,7 @@ import { TrainerService } from '../services/trainer-service/trainer.service';
 import {TranslatePipe, TranslateService} from '@ngx-translate/core';
 import { isMegaStoneItemName } from '../services/items-service/item-names';
 import { ImageFallbackDirective } from '../directives/image-fallback.directive';
+import { MegaStoneActivation } from '../services/mega-stone-service/mega-stone.service';
 
 @Component({
   selector: 'app-items',
@@ -33,7 +34,7 @@ export class ItemsComponent implements OnInit, OnDestroy {
   /** Slot indices for the item grid. The bag renders a fixed twelve, filled or not. */
   readonly slots = Array.from({ length: 12 }, (_, index) => index);
   @Output() rareCandyInterrupt = new EventEmitter<ItemItem>();
-  @Output() megaStoneInterrupt = new EventEmitter<ItemItem>();
+  @Output() megaStoneInterrupt = new EventEmitter<MegaStoneActivation>();
 
   darkMode!: Observable<boolean>;
   private itemsSubscription!: Subscription;
@@ -53,7 +54,7 @@ export class ItemsComponent implements OnInit, OnDestroy {
       if (item.name === 'rare-candy') {
         this.rareCandyInterrupt.emit(item);
       } else if (isMegaStoneItemName(item.name)) {
-        this.megaStoneInterrupt.emit(item);
+        this.megaStoneInterrupt.emit({ stone: item });
       }
     }
   }

--- a/src/app/main-game/main-game.component.ts
+++ b/src/app/main-game/main-game.component.ts
@@ -17,7 +17,7 @@ import { LanguageSelectorComponent } from './language-selector/language-selector
 import { RouletteContainerComponent } from './roulette-container/roulette-container.component';
 import { SettingsButtonComponent } from '../settings-button/settings-button.component';
 import { RareCandyService } from '../services/rare-candy-service/rare-candy.service';
-import { MegaStoneService } from '../services/mega-stone-service/mega-stone.service';
+import { MegaStoneActivation, MegaStoneService } from '../services/mega-stone-service/mega-stone.service';
 
 @Component({
   selector: 'app-main-game',
@@ -77,12 +77,12 @@ export class MainGameComponent implements OnInit {
     this.rareCandyService.triggerRareCandyEvolution(rareCandy);
   }
 
-  megaStoneInterrupt(megaStone: ItemItem): void {
+  megaStoneInterrupt(activation: MegaStoneActivation): void {
     if (this.wheelSpinning) {
       return;
     }
 
-    this.megaStoneService.triggerMegaStoneActivation(megaStone);
+    this.megaStoneService.triggerMegaStoneActivation(activation);
   }
 
   resetGame(): void {

--- a/src/app/main-game/roulette-container/roulette-container.component.spec.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.spec.ts
@@ -205,7 +205,7 @@ describe('RouletteContainerComponent', () => {
     it('records the win against the base Pokémon, not the mega form', () => {
       trainerService.addToTeam(pokemonService.getPokemonById(CHARIZARD)!);
       giveStone('charizardite-x');
-      trainerService.forceMegaActivation(CHARIZARD, 'charizardite-x' as any);
+      trainerService.forceMegaActivation(trainerService.getTeam()[0], 'charizardite-x' as any);
       expect(trainerService.getTeam()[0].pokemonId)
         .withContext('the Pokémon must actually be mega-evolved when the champion falls')
         .toBe(MEGA_CHARIZARD_X);

--- a/src/app/main-game/roulette-container/roulette-container.component.ts
+++ b/src/app/main-game/roulette-container/roulette-container.component.ts
@@ -56,7 +56,7 @@ import { EndGameComponent } from "../end-game/end-game.component";
 import { GameOverComponent } from "../game-over/game-over.component";
 import { ModalQueueService } from '../../services/modal-queue-service/modal-queue.service';
 import { PokemonFormsService } from '../../services/pokemon-forms-service/pokemon-forms.service';
-import { MegaStoneService } from '../../services/mega-stone-service/mega-stone.service';
+import { MegaStoneActivation, MegaStoneService } from '../../services/mega-stone-service/mega-stone.service';
 import { megaStoneNamesForBaseId, pokemonMegaForms } from '../../services/trainer-service/pokemon-mega-forms';
 import { MegaEvolutionAnimationModalComponent } from './roulettes/mega-evolution-animation-modal/mega-evolution-animation-modal.component';
 import { SelectFromItemListRouletteComponent } from './roulettes/select-from-item-list-roulette/select-from-item-list-roulette.component';
@@ -159,8 +159,8 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
       this.handleRareCandyEvolution(rareCandy);
     });
 
-    this.megaStoneSubscription = this.megaStoneService.megaStoneTrigger$.subscribe((megaStone) => {
-      this.handleMegaStoneActivation(megaStone);
+    this.megaStoneSubscription = this.megaStoneService.megaStoneTrigger$.subscribe((activation) => {
+      this.handleMegaStoneActivation(activation);
     });
   }
 
@@ -847,7 +847,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
   }
 
 
-  private handleMegaStoneActivation(megaStone: ItemItem): void {
+  private handleMegaStoneActivation({ stone: megaStone, pokemon }: MegaStoneActivation): void {
     if (!this.isBattleState(this.currentGameState)) {
       return;
     }
@@ -867,8 +867,11 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const matchingPokemon = this.getPokemonMatchingMegaStone(megaStone.name);
-    if (matchingPokemon.length === 0) {
+    // The team member the player actually tapped, when there was one. Falling
+    // back to the first match is only for a stone tapped in the bag, where
+    // nothing was pointed at.
+    const target = pokemon ?? this.getPokemonMatchingMegaStone(megaStone.name)[0];
+    if (!target) {
       return;
     }
 
@@ -882,7 +885,7 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
       ]);
     }
 
-    this.activateMegaEvolutionForPokemon(matchingPokemon[0].pokemonId, megaStone.name);
+    this.activateMegaEvolutionForPokemon(target, megaStone.name);
   }
 
   private getPokemonMatchingMegaStone(stoneName: MegaStoneItemName): PokemonItem[] {
@@ -903,9 +906,10 @@ export class RouletteContainerComponent implements OnInit, OnDestroy {
     return matching;
   }
 
-  private activateMegaEvolutionForPokemon(basePokemonId: number, stoneName?: MegaStoneItemName): void {
+  private activateMegaEvolutionForPokemon(target: PokemonItem, stoneName?: MegaStoneItemName): void {
+    const basePokemonId = target.pokemonId;
     this.trainerService.setMegaBattlePokemon(basePokemonId);
-    this.trainerService.forceMegaActivation(basePokemonId, stoneName);
+    this.trainerService.forceMegaActivation(target, stoneName);
     this.pokedexService.markMega(basePokemonId);
     void this.showMegaEvolutionAnimation(basePokemonId, stoneName);
   }

--- a/src/app/services/achievement-service/achievement-catalog.spec.ts
+++ b/src/app/services/achievement-service/achievement-catalog.spec.ts
@@ -73,13 +73,4 @@ describe('the achievement catalog', () => {
     expect(progress.current).toBe(2);
   });
 
-  it('hides the achievements a player may never be able to earn', () => {
-    // Region-locked encounters: a player who only ever visits Johto cannot
-    // reach these, and three permanently locked rows read as broken.
-    for (const id of ['five_hundred_steps', 'friend_code', 'the_great_crater']) {
-      expect(ACHIEVEMENTS.find(a => a.id === id)!.hidden)
-        .withContext(`${id} is region-locked and should be hidden`)
-        .toBeTrue();
-    }
-  });
 });

--- a/src/app/services/achievement-service/achievement-catalog.ts
+++ b/src/app/services/achievement-service/achievement-catalog.ts
@@ -43,13 +43,6 @@ export type AchievementGroup =
 export interface Achievement {
   readonly id: string;
   readonly group: AchievementGroup;
-  /**
-   * Hidden until earned, so there is something to discover rather than a
-   * checklist to grind. Also used for the three region-locked encounters, which
-   * a player who never visits that region can never earn — a permanently
-   * locked visible row reads as broken.
-   */
-  readonly hidden?: boolean;
   readonly progress: (context: AchievementContext) => Progress;
 }
 
@@ -162,7 +155,7 @@ export const ACHIEVEMENTS: readonly Achievement[] = [
   { id: 'regional_champion', group: 'champion', progress: c => ({ current: championedRegions(c), target: 3 }) },
   { id: 'world_champion', group: 'champion', progress: c => ({ current: championedRegions(c), target: 9 }) },
   { id: 'full_house', group: 'champion', progress: counter('champion_with_six', 1) },
-  { id: 'pokemon_stadium', group: 'champion', hidden: true, progress: counter('champion_with_three_or_fewer', 1) },
+  { id: 'pokemon_stadium', group: 'champion', progress: counter('champion_with_three_or_fewer', 1) },
 
   // Rival.
   { id: 'smell_ya_later', group: 'rival', progress: counter('rival_battles_won', 1) },
@@ -186,9 +179,9 @@ export const ACHIEVEMENTS: readonly Achievement[] = [
   // Region-locked: Kanto, Kalos and Paldea only. Hidden, because a player who
   // never visits those regions would otherwise stare at three rows they cannot
   // earn and reasonably conclude something is broken.
-  { id: 'five_hundred_steps', group: 'encounters', hidden: true, progress: counter('safari_zone_visits', 1) },
-  { id: 'friend_code', group: 'encounters', hidden: true, progress: counter('friend_safari_visits', 1) },
-  { id: 'the_great_crater', group: 'encounters', hidden: true, progress: counter('area_zero_visits', 1) },
+  { id: 'five_hundred_steps', group: 'encounters', progress: counter('safari_zone_visits', 1) },
+  { id: 'friend_code', group: 'encounters', progress: counter('friend_safari_visits', 1) },
+  { id: 'the_great_crater', group: 'encounters', progress: counter('area_zero_visits', 1) },
   { id: 'a_fair_trade', group: 'encounters', progress: counter('trades_completed', 1) },
 
   // Badge dex.

--- a/src/app/services/auth-service/auth.service.ts
+++ b/src/app/services/auth-service/auth.service.ts
@@ -14,6 +14,22 @@ interface ApiErrorEnvelope {
 }
 
 /**
+ * API error codes this build can say something better than English about.
+ *
+ * `invalid_request` is deliberately generic here. The server sends a precise
+ * message for it -- which password rule was broken, say -- but the client
+ * checks those rules itself before submitting and says so in the player's own
+ * language, so reaching this is already an edge case.
+ */
+const ERROR_KEYS: Readonly<Record<string, string>> = {
+  unauthorized: 'account.error.credentials',
+  conflict: 'account.error.emailTaken',
+  rate_limited: 'account.error.rateLimited',
+  invalid_request: 'account.error.invalid',
+  internal: 'account.error.server',
+};
+
+/**
  * Accounts, and whether there is one.
  *
  * **The game works with no account, forever.** Nothing here may gate play: a
@@ -101,11 +117,39 @@ export class AuthService {
   }
 
   /**
-   * The message to show a player for a failed request.
+   * The translation key for a failed request, or `null` to show the server's
+   * own words.
    *
-   * Returns exactly what the API said. The signup and login endpoints answer
-   * "wrong password" and "no such account" identically **on purpose**, and a
-   * client that guesses a more specific message undoes that on the front end.
+   * Translating by **code** rather than by message is what lets this be
+   * localised at all. Showing the server's text verbatim was deliberate --
+   * login answers "wrong password" and "no such account" identically, and a
+   * client that guesses a more specific message undoes that -- but verbatim
+   * also meant English, in a game that ships in six languages. Mapping the
+   * code preserves the ambiguity exactly, because the *code* is identical in
+   * both cases too.
+   *
+   * A code this build does not recognise falls through to the server's text.
+   * The API deploys on its own schedule, and an English sentence that is
+   * precise beats a translated one that is wrong.
+   */
+  static errorKeyFor(error: unknown): string | null {
+    if (!(error instanceof HttpErrorResponse)) {
+      return null;
+    }
+
+    // No status at all is the network being unreachable, which the server
+    // never got to have an opinion about.
+    if (error.status === 0) {
+      return 'account.error.offline';
+    }
+
+    const code = (error.error as ApiErrorEnvelope | null)?.error?.code;
+    return code && Object.hasOwn(ERROR_KEYS, code) ? ERROR_KEYS[code] : null;
+  }
+
+  /**
+   * The message to show a player for a failed request, when no translation
+   * applies. Returns exactly what the API said.
    */
   static messageFor(error: unknown, fallback: string): string {
     if (error instanceof HttpErrorResponse) {

--- a/src/app/services/form-rule-service/form-rule.service.ts
+++ b/src/app/services/form-rule-service/form-rule.service.ts
@@ -109,15 +109,29 @@ export class FormRuleService {
     return reverted;
   }
 
-  /** Applies one rule immediately — used when a stone is tapped mid-battle. */
-  forceApply(ruleId: string, team: PokemonItem[], stored: PokemonItem[], heldItems: readonly ItemName[]): boolean {
+  /**
+   * Applies one rule immediately — used when a stone is tapped mid-battle.
+   *
+   * `target` limits it to a single Pokémon, by identity. Without it, a player
+   * carrying two Kangaskhan and tapping one stone mega evolved **both**: the
+   * rule matches on species, and every member of the collection that matches
+   * is transformed. That is right for a rule that fires on battle start and
+   * wrong for one a player triggers by pointing at something.
+   */
+  forceApply(
+    ruleId: string,
+    team: PokemonItem[],
+    stored: PokemonItem[],
+    heldItems: readonly ItemName[],
+    target?: PokemonItem,
+  ): boolean {
     const rule = this.rulesById.get(ruleId);
     if (!rule) {
       return false;
     }
     // A forced application still has to be undone at battle end.
     this.formsApplied = true;
-    return this.applyRule(rule, team, stored, heldItems);
+    return this.applyRule(rule, team, stored, heldItems, target);
   }
 
   /** True when any collection currently holds a non-base form of the given rule. */
@@ -140,12 +154,19 @@ export class FormRuleService {
 
   private applyRule(
     rule: FormRule, team: PokemonItem[], stored: PokemonItem[], heldItems: readonly ItemName[],
+    only?: PokemonItem,
   ): boolean {
     let changed = false;
 
     for (const collection of this.collectionsFor(rule, team, stored)) {
       for (let i = 0; i < collection.length; i++) {
         const current = collection[i];
+        // Identity, not species: two of the same Pokémon are the same species
+        // and the same stone, and only one of them was pointed at.
+        if (only && current !== only) {
+          continue;
+        }
+
         const target = this.pickTarget(rule, current, heldItems);
         if (!target || target.pokemonId === current.pokemonId) {
           continue;

--- a/src/app/services/mega-stone-service/mega-stone.service.ts
+++ b/src/app/services/mega-stone-service/mega-stone.service.ts
@@ -1,18 +1,33 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 import { ItemItem } from '../../interfaces/item-item';
+import { PokemonItem } from '../../interfaces/pokemon-item';
+
+/**
+ * A request to mega evolve.
+ *
+ * `pokemon` is the exact team member whose stone was tapped, and it is the
+ * reason this is an object rather than the bare item: two of the same species
+ * hold the same stone, so the stone alone cannot say which one the player
+ * meant. It is absent when the stone was tapped in the bag, where there is
+ * nothing to point at.
+ */
+export interface MegaStoneActivation {
+  readonly stone: ItemItem;
+  readonly pokemon?: PokemonItem;
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class MegaStoneService {
-  private megaStoneTriggerSubject = new Subject<ItemItem>();
+  private megaStoneTriggerSubject = new Subject<MegaStoneActivation>();
 
   get megaStoneTrigger$() {
     return this.megaStoneTriggerSubject.asObservable();
   }
 
-  triggerMegaStoneActivation(megaStone: ItemItem): void {
-    this.megaStoneTriggerSubject.next(megaStone);
+  triggerMegaStoneActivation(activation: MegaStoneActivation): void {
+    this.megaStoneTriggerSubject.next(activation);
   }
 }

--- a/src/app/services/sync-service/sync.service.spec.ts
+++ b/src/app/services/sync-service/sync.service.spec.ts
@@ -180,6 +180,26 @@ describe('SyncService', () => {
     expect(status()).toBe('off');
   }));
 
+  it('keeps preferences but no collections when the player signs out', () => {
+    // The shared-device reasoning that justifies wiping a Pokédex does not
+    // reach a theme: nobody is contaminated by inheriting dark mode, and
+    // wiping it signed a Brazilian player out into an English, light game.
+    localStorage.setItem('pokemon-roulette-settings', '{"muteAudio":true}');
+    localStorage.setItem('pokemon-roulette-theme', 'plain-dark');
+    localStorage.setItem('language', 'pt');
+    localStorage.setItem('pokemon-roulette-pokedex', '{"caught":{"25":{"won":true}}}');
+    localStorage.setItem('pokemon-roulette-stats', '{"spins_total":9}');
+    localStorage.setItem('pokemon-roulette-badge-dex', '["boulder"]');
+    localStorage.setItem('pokemon-roulette-achievements', '{"i_choose_you":"2026-01-01T00:00:00Z"}');
+    localStorage.setItem('pokemon-roulette-synced', 'true');
+
+    sync.clearLocalData();
+
+    expect(Object.keys(localStorage).sort()).toEqual([
+      'language', 'pokemon-roulette-settings', 'pokemon-roulette-theme',
+    ]);
+  });
+
   const status = (): SyncStatus => {
     let current: SyncStatus = 'off';
     sync.status$.subscribe(value => (current = value)).unsubscribe();

--- a/src/app/services/sync-service/sync.service.ts
+++ b/src/app/services/sync-service/sync.service.ts
@@ -12,6 +12,21 @@ import { AchievementService } from '../achievement-service/achievement.service';
 import { SettingsService } from '../settings-service/settings.service';
 import { SyncSnapshot, mergeSnapshots, parseSyncSnapshot } from './sync-snapshot';
 
+/**
+ * Preferences, which survive signing out. Everything else is a collection and
+ * is wiped.
+ *
+ * An allowlist rather than a denylist on purpose: a new *collection* added to
+ * storage and forgotten about must default to being wiped, because leaving it
+ * behind is the failure that cannot be undone. A new preference forgotten
+ * about is merely reset.
+ */
+const KEPT_ON_SIGN_OUT: ReadonlySet<string> = new Set([
+  'pokemon-roulette-settings',
+  'pokemon-roulette-theme',
+  'language',
+]);
+
 /** What the account screen shows. Nothing more intrusive than this exists. */
 export type SyncStatus = 'off' | 'syncing' | 'synced' | 'pending' | 'offline';
 
@@ -99,26 +114,39 @@ export class SyncService {
   }
 
   /**
-   * Erases every collection from this device.
+   * Erases every collection from this device, and keeps the preferences.
    *
-   * Signing out wipes local data, which is the opposite of the usual default
+   * Signing out wipes collections, which is the opposite of the usual default
    * and is deliberate: this game gets played on shared devices, and leaving a
-   * collection behind means the next person silently merges their progress
-   * into someone else's. Grow-only data cannot be separated back out
-   * afterwards, so the contamination would be permanent.
+   * Pokédex behind means the next person silently merges their progress into
+   * someone else's. Grow-only data cannot be separated back out afterwards,
+   * so the contamination would be permanent.
+   *
+   * **Preferences are not collections and are kept.** Nobody is harmed by
+   * inheriting a dark theme, and wiping them meant a Brazilian player in dark
+   * mode signed out into an English, light game every time. The line is
+   * whether the data is *about the player* or about this browser.
    *
    * Reloading afterwards rather than resetting each service in place: every
    * service holds its state in memory, and a missed one would resurrect the
    * previous player's Pokédex the next time it wrote to storage.
    */
   clearLocalDataAndReload(): void {
+    this.clearLocalData();
+    window.location.reload();
+  }
+
+  /** The wipe itself, without the reload, so it can be tested. */
+  clearLocalData(): void {
     try {
-      localStorage.clear();
+      for (const key of Object.keys(localStorage)) {
+        if (!KEPT_ON_SIGN_OUT.has(key)) {
+          localStorage.removeItem(key);
+        }
+      }
     } catch (error) {
       console.error('Failed to clear local data on sign out:', error);
     }
-
-    window.location.reload();
   }
 
   private schedule(delayMs: number): void {

--- a/src/app/services/trainer-service/trainer.service.spec.ts
+++ b/src/app/services/trainer-service/trainer.service.spec.ts
@@ -283,7 +283,7 @@ describe('TrainerService', () => {
     });
 
     it('gives Mega Y when Charizardite Y is the stone tapped', () => {
-      service.forceMegaActivation(CHARIZARD, 'charizardite-y' as any);
+      service.forceMegaActivation(service.trainerTeam[0], 'charizardite-y' as any);
 
       expect(service.trainerTeam[0].pokemonId)
         .withContext('holding X as well must not override the stone the player tapped')
@@ -291,13 +291,28 @@ describe('TrainerService', () => {
     });
 
     it('gives Mega X when Charizardite X is the stone tapped', () => {
-      service.forceMegaActivation(CHARIZARD, 'charizardite-x' as any);
+      service.forceMegaActivation(service.trainerTeam[0], 'charizardite-x' as any);
 
       expect(service.trainerTeam[0].pokemonId).toBe(MEGA_X);
     });
 
+    it('mega evolves only the Pokémon that was tapped, not every copy of it', () => {
+      // Reported from a real run: two Kangaskhan on the team, tap one stone,
+      // both transformed. The rule matches on species, so every member of the
+      // collection matched -- right for a rule that fires on battle start,
+      // wrong for one the player triggers by pointing at something.
+      service.trainerTeam = [structuredClone(charizard), structuredClone(charizard)];
+
+      service.forceMegaActivation(service.trainerTeam[1], 'charizardite-x' as any);
+
+      expect(service.trainerTeam[1].pokemonId).toBe(MEGA_X);
+      expect(service.trainerTeam[0].pokemonId)
+        .withContext('the other one was never pointed at')
+        .toBe(CHARIZARD);
+    });
+
     it('falls back to any held stone when none was named', () => {
-      service.forceMegaActivation(CHARIZARD);
+      service.forceMegaActivation(service.trainerTeam[0]);
 
       expect([MEGA_X, MEGA_Y]).toContain(service.trainerTeam[0].pokemonId);
     });

--- a/src/app/services/trainer-service/trainer.service.ts
+++ b/src/app/services/trainer-service/trainer.service.ts
@@ -321,14 +321,17 @@ export class TrainerService implements OnDestroy {
   }
 
   /** Applies mega evolution immediately for the selected base Pokémon during a battle. */
-  forceMegaActivation(baseId: number, stoneName?: MegaStoneItemName): void {
+  forceMegaActivation(target: PokemonItem, stoneName?: MegaStoneItemName): void {
+    const baseId = target.pokemonId;
     this.megaBattleBaseId = baseId;
 
     // Offer *only* the tapped stone. The rule scans its own forms in order rather than the list it
     // is handed, so passing the others would let forms[0] win whichever stone the player tapped.
     const heldItems = stoneName && this.hasItem(stoneName) ? [stoneName] : this.heldItemNames();
+    // The tapped Pokémon, by identity. Passing only the species mega evolved
+    // every copy of it on the team.
     const changed = this.formRuleService.forceApply(
-      `mega:${baseId}`, this.trainerTeam, this.storedPokemon, heldItems,
+      `mega:${baseId}`, this.trainerTeam, this.storedPokemon, heldItems, target,
     );
 
     if (changed) {

--- a/src/app/settings/account/account.component.css
+++ b/src/app/settings/account/account.component.css
@@ -78,3 +78,7 @@
   border: 0;
   vertical-align: baseline;
 }
+
+.account-mismatch {
+  color: #dc3545;
+}

--- a/src/app/settings/account/account.component.html
+++ b/src/app/settings/account/account.component.html
@@ -110,9 +110,25 @@
       </small>
 
       @if (mode === 'signup') {
+        <label class="account-label" for="account-password-confirm">
+          {{ 'account.confirmPassword' | translate }}
+        </label>
+        <input id="account-password-confirm" class="form-control form-control-sm"
+               type="password" autocomplete="new-password"
+               [class.is-invalid]="touched && !confirmationValid"
+               [value]="passwordConfirmation"
+               (input)="passwordConfirmation = $any($event.target).value"
+               (keyup.enter)="submit()">
+        @if (touched && !confirmationValid) {
+          <small class="account-hint account-mismatch">
+            {{ 'account.passwordMismatch' | translate }}
+          </small>
+        }
+
         <!-- Stated at the point of signup, not buried. There is no SMTP, so a
              forgotten password is an unrecoverable account, and someone could
-             lose a 900-Pokémon Pokédex to it. -->
+             lose a 900-Pokémon Pokédex to it. That is also why the password is
+             asked for twice: a typo here is an account nobody can open. -->
         <p class="account-warning">{{ 'account.noResetWarning' | translate }}</p>
       }
 
@@ -127,6 +143,13 @@
   }
 
   @if (error) {
-    <p class="account-error" role="alert">{{ error }}</p>
+    <p class="account-error" role="alert">
+      {{ error }}
+      @if (emailTaken) {
+        <button type="button" class="btn btn-link btn-sm account-retry" (click)="switchToSignIn()">
+          {{ 'account.signIn' | translate }}
+        </button>
+      }
+    </p>
   }
 </section>

--- a/src/app/settings/account/account.component.spec.ts
+++ b/src/app/settings/account/account.component.spec.ts
@@ -194,21 +194,57 @@ describe('AccountComponent', () => {
 
   // Rewording here would undo the server's deliberate refusal to say which of
   // the two things was wrong.
-  it('shows the server\'s own message on failure', () => {
-    answerWhoAmI();
+  describe('error messages', () => {
 
-    component.email = 'ash@pallet.town';
-    component.password = 'pikachu-i-choose-you';
-    component.submit();
+    const failLogin = (body: object, status: number) => {
+      component.email = 'ash@pallet.town';
+      component.password = 'pikachu-i-choose-you';
+      component.submit();
+      http.expectOne(`${base}/auth/login`).flush(body, { status, statusText: 'Error' });
+      fixture.detectChanges();
+    };
 
-    http.expectOne(`${base}/auth/login`).flush(
-      { error: { code: 'unauthorized', message: 'That email and password do not match an account.' } },
-      { status: 401, statusText: 'Unauthorized' },
-    );
-    fixture.detectChanges();
+    it('translates a failure this build recognises', () => {
+      // Keyed on the error *code*, never on the server's text, which is
+      // English only. Five of the six locales would otherwise read English.
+      answerWhoAmI();
 
-    expect(component.error).toBe('That email and password do not match an account.');
-    expect(component.busy).toBeFalse();
+      failLogin({ error: { code: 'unauthorized', message: 'That email and password do not match an account.' } }, 401);
+
+      expect(component.error).toBe('account.error.credentials');
+      expect(component.busy).toBeFalse();
+    });
+
+    it('gives a wrong password and an unknown account the same message', () => {
+      // The API refuses to distinguish them. Translating by code keeps that
+      // true, because the code is identical in both cases.
+      answerWhoAmI();
+
+      failLogin({ error: { code: 'unauthorized', message: 'That email and password do not match an account.' } }, 401);
+      const wrongPassword = component.error;
+
+      failLogin({ error: { code: 'unauthorized', message: 'That email and password do not match an account.' } }, 401);
+
+      expect(component.error).toBe(wrongPassword);
+    });
+
+    it('falls back to the server\'s own words for a code it has never met', () => {
+      // The API deploys on its own schedule. An English sentence that is
+      // precise beats a translated one that is wrong.
+      answerWhoAmI();
+
+      failLogin({ error: { code: 'teapot', message: 'Something specific and new.' } }, 418);
+
+      expect(component.error).toBe('Something specific and new.');
+    });
+
+    it('says the server was unreachable rather than blaming the player', () => {
+      answerWhoAmI();
+
+      failLogin(new ProgressEvent('error'), 0);
+
+      expect(component.error).toBe('account.error.offline');
+    });
   });
 
   it('needs a password before it will delete anything', () => {

--- a/src/app/settings/account/account.component.spec.ts
+++ b/src/app/settings/account/account.component.spec.ts
@@ -118,9 +118,78 @@ describe('AccountComponent', () => {
     component.setMode('signup');
     component.email = 'new@pallet.town';
     component.password = 'a-long-enough-password';
+    component.passwordConfirmation = 'a-long-enough-password';
     component.submit();
 
     http.expectOne(`${base}/auth/signup`).flush({ id: 'abc', email: 'new@pallet.town' });
+  });
+
+  describe('signing up', () => {
+
+    it('will not submit until the password is typed twice and matches', () => {
+      // There is no password reset, so a typo in a single field would be an
+      // account nobody can ever open.
+      answerWhoAmI();
+
+      component.setMode('signup');
+      component.email = 'new@pallet.town';
+      component.password = 'a-long-enough-password';
+      component.passwordConfirmation = 'a-long-enough-passwrod';
+      component.submit();
+
+      http.expectNone(`${base}/auth/signup`);
+      expect(component.confirmationValid).toBeFalse();
+
+      component.passwordConfirmation = 'a-long-enough-password';
+      component.submit();
+      http.expectOne(`${base}/auth/signup`).flush({ id: 'abc', email: 'new@pallet.town' });
+    });
+
+    it('does not ask for a confirmation when signing in', () => {
+      answerWhoAmI();
+
+      component.email = 'ash@pallet.town';
+      component.password = 'a-long-enough-password';
+
+      expect(component.confirmationValid).toBeTrue();
+      expect(component.canSubmit).toBeTrue();
+    });
+
+    it('accepts eight characters, as the server now does', () => {
+      answerWhoAmI();
+
+      component.email = 'new@pallet.town';
+      component.password = '12345678';
+
+      expect(component.passwordValid).toBeTrue();
+
+      component.password = '1234567';
+      expect(component.passwordValid).toBeFalse();
+    });
+
+    it('offers to sign in when the address is already registered', () => {
+      answerWhoAmI();
+
+      component.setMode('signup');
+      component.email = 'ash@pallet.town';
+      component.password = 'a-long-enough-password';
+      component.passwordConfirmation = 'a-long-enough-password';
+      component.submit();
+
+      http.expectOne(`${base}/auth/signup`).flush(
+        { error: { code: 'conflict', message: 'An account with that email already exists. Sign in instead.' } },
+        { status: 409, statusText: 'Conflict' },
+      );
+      fixture.detectChanges();
+
+      expect(component.emailTaken).toBeTrue();
+
+      // The button keeps what was typed rather than making them start again.
+      component.switchToSignIn();
+      expect(component.mode).toBe('signin');
+      expect(component.email).toBe('ash@pallet.town');
+      expect(component.password).toBe('a-long-enough-password');
+    });
   });
 
   // Rewording here would undo the server's deliberate refusal to say which of

--- a/src/app/settings/account/account.component.ts
+++ b/src/app/settings/account/account.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, Subscription } from 'rxjs';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 
@@ -8,7 +9,7 @@ import { SyncStateService } from '../../services/sync-state-service/sync-state.s
 import { SyncService, SyncStatus } from '../../services/sync-service/sync.service';
 
 /** Matches the backend, which rejects anything shorter. */
-const MIN_PASSWORD_LENGTH = 12;
+const MIN_PASSWORD_LENGTH = 8;
 
 /**
  * Permissive on purpose, like the server's own check: this rejects nonsense
@@ -58,8 +59,15 @@ export class AccountComponent implements OnInit, OnDestroy {
   // to breach the bundle budget on its own.
   email = '';
   password = '';
+  // Signup only. There is no password reset, so a typo in the one field would
+  // be an account nobody can ever open -- which is the whole reason to ask
+  // twice. Signing in does not need it: getting it wrong there just fails.
+  passwordConfirmation = '';
   deletePassword = '';
   touched = false;
+
+  /** Set when signup was refused because the address is already registered. */
+  emailTaken = false;
 
   private readonly subscriptions = new Subscription();
 
@@ -81,6 +89,17 @@ export class AccountComponent implements OnInit, OnDestroy {
     this.mode = mode;
     this.error = '';
     this.touched = false;
+    this.emailTaken = false;
+    this.passwordConfirmation = '';
+  }
+
+  /** Offered when signup reports the address is taken; keeps what was typed. */
+  switchToSignIn(): void {
+    const email = this.email;
+    const password = this.password;
+    this.setMode('signin');
+    this.email = email;
+    this.password = password;
   }
 
   get emailValid(): boolean {
@@ -91,12 +110,17 @@ export class AccountComponent implements OnInit, OnDestroy {
     return this.password.length >= MIN_PASSWORD_LENGTH;
   }
 
+  get confirmationValid(): boolean {
+    return this.mode === 'signin' || this.passwordConfirmation === this.password;
+  }
+
   get canSubmit(): boolean {
-    return this.emailValid && this.passwordValid && !this.busy;
+    return this.emailValid && this.passwordValid && this.confirmationValid && !this.busy;
   }
 
   submit(): void {
     this.touched = true;
+    this.emailTaken = false;
 
     if (!this.canSubmit) {
       return;
@@ -110,6 +134,7 @@ export class AccountComponent implements OnInit, OnDestroy {
     this.run(request, 'account.error.generic', () => {
       this.email = '';
       this.password = '';
+      this.passwordConfirmation = '';
       this.touched = false;
     });
   }
@@ -182,6 +207,9 @@ export class AccountComponent implements OnInit, OnDestroy {
       error: (failure: unknown) => {
         this.busy = false;
         this.error = AuthService.messageFor(failure, this.translate.instant(fallbackKey) as string);
+        // The server's message says "Sign in instead"; this is the button
+        // that does it, rather than making them find the tab and retype.
+        this.emailTaken = failure instanceof HttpErrorResponse && failure.status === 409;
       },
     });
   }

--- a/src/app/settings/account/account.component.ts
+++ b/src/app/settings/account/account.component.ts
@@ -189,11 +189,12 @@ export class AccountComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Runs a request, showing whatever the server said on failure.
+   * Runs a request, showing a translated message for any failure this build
+   * recognises and the server's own words for anything else.
    *
-   * Deliberately not translated and not reworded: signup and login answer
-   * "wrong password" and "no account" identically on purpose, and inventing a
-   * more specific message here would undo that.
+   * The translation is keyed on the API's error *code*, never on its text.
+   * Signup and login answer "wrong password" and "no account" identically on
+   * purpose, and their codes match too, so this cannot undo that.
    */
   private run<T>(request: Observable<T>, fallbackKey: string, onSuccess?: () => void): void {
     this.busy = true;
@@ -206,7 +207,12 @@ export class AccountComponent implements OnInit, OnDestroy {
       },
       error: (failure: unknown) => {
         this.busy = false;
-        this.error = AuthService.messageFor(failure, this.translate.instant(fallbackKey) as string);
+
+        const key = AuthService.errorKeyFor(failure);
+        this.error = key
+          ? (this.translate.instant(key) as string)
+          : AuthService.messageFor(failure, this.translate.instant(fallbackKey) as string);
+
         // The server's message says "Sign in instead"; this is the button
         // that does it, rather than making them find the tab and retype.
         this.emailTaken = failure instanceof HttpErrorResponse && failure.status === 409;

--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -1,0 +1,32 @@
+/*
+ * Bootstrap's `.form-switch` assumes the input comes first inside a
+ * `.form-check` and pulls it 2.5em to the left to sit in that padding. These
+ * rows put the label first instead, so the negative margin drags the switch
+ * back over the end of the label text.
+ *
+ * Invisible in English, where every label is short. In German at 375px it ate
+ * the last word: "Mega-Entwicklungsanimation überspringen" was clipped
+ * mid-word by its own switch.
+ */
+.form-switch.d-flex {
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.form-switch.d-flex .form-check-input {
+  margin-left: 0;
+  flex: none;
+}
+
+.form-switch.d-flex .form-check-label {
+  /* min-width lets a long label wrap instead of forcing the row wider. */
+  flex: 1;
+  min-width: 0;
+}
+
+/* The gender radios are a different Bootstrap structure, and the longest
+   label ("Immer Mädchen") ends up flush against its control. Not a collision,
+   but nothing should touch. */
+.form-check .form-check-label {
+  padding-left: 0.35rem;
+}

--- a/src/app/trainer-team/achievements/achievements.component.css
+++ b/src/app/trainer-team/achievements/achievements.component.css
@@ -55,12 +55,6 @@
   background: rgba(245, 197, 24, 0.14);
 }
 
-.achievement-row.concealed .achievement-name,
-.achievement-row.concealed .achievement-description {
-  opacity: 0.5;
-  font-style: italic;
-}
-
 .achievement-text {
   display: flex;
   flex-direction: column;

--- a/src/app/trainer-team/achievements/achievements.component.html
+++ b/src/app/trainer-team/achievements/achievements.component.html
@@ -1,63 +1,41 @@
-<button type="button" class="btn"
-  [ngClass]="(darkMode | async) ? 'btn-outline-light' : 'btn-outline-dark'"
-  (click)="openAchievements()">
-  <ng-icon name="bootstrapAward"></ng-icon>
-  {{ 'achievementsScreen.button' | translate }}
-</button>
+<section class="lifetime-totals">
+  @for (total of totals; track total.labelKey) {
+    <div class="lifetime-total">
+      <span class="lifetime-value">{{ total.value }}</span>
+      <span class="lifetime-label">{{ total.labelKey | translate }}</span>
+    </div>
+  }
+</section>
 
-<ng-template #achievementsModal let-modal>
-  <div class="modal-header" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
-    <h4 class="modal-title">
-      {{ 'achievementsScreen.title' | translate }}
-      <small class="achievements-count">{{ unlockedCount }} / {{ total }}</small>
-    </h4>
-    <button type="button" class="btn-close"
-      [ngClass]="(darkMode | async) ? 'btn-close-white' : ''"
-      (click)="closeModal()" aria-label="Close"></button>
-  </div>
+@for (group of groups; track group.group) {
+  <section class="achievement-group">
+    <h5 class="achievement-group-title">{{ groupLabelKey(group.group) | translate }}</h5>
 
-  <div class="modal-body" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
+    @for (achievement of group.achievements; track achievement.id) {
+      <div class="achievement-row" [class.unlocked]="isUnlocked(achievement)">
 
-    <section class="lifetime-totals">
-      @for (total of totals; track total.labelKey) {
-        <div class="lifetime-total">
-          <span class="lifetime-value">{{ total.value }}</span>
-          <span class="lifetime-label">{{ total.labelKey | translate }}</span>
+        <div class="achievement-text">
+          <span class="achievement-name">{{ nameKey(achievement) | translate }}</span>
+          <span class="achievement-description">{{ descriptionKey(achievement) | translate }}</span>
         </div>
-      }
-    </section>
 
-    @for (group of groups; track group.group) {
-      <section class="achievement-group">
-        <h5 class="achievement-group-title">{{ groupLabelKey(group.group) | translate }}</h5>
-
-        @for (achievement of group.achievements; track achievement.id) {
-          <div class="achievement-row" [class.unlocked]="isUnlocked(achievement)">
-
-            <div class="achievement-text">
-              <span class="achievement-name">{{ nameKey(achievement) | translate }}</span>
-              <span class="achievement-description">{{ descriptionKey(achievement) | translate }}</span>
+        <div class="achievement-progress">
+          @if (isUnlocked(achievement)) {
+            <span class="achievement-tick" aria-hidden="true">&check;</span>
+          } @else {
+            <div class="progress-track"
+                 role="progressbar"
+                 [attr.aria-valuenow]="percentFor(achievement)"
+                 aria-valuemin="0"
+                 aria-valuemax="100">
+              <div class="progress-fill" [style.width.%]="percentFor(achievement)"></div>
             </div>
-
-            <div class="achievement-progress">
-              @if (isUnlocked(achievement)) {
-                <span class="achievement-tick" aria-hidden="true">&check;</span>
-              } @else {
-                <div class="progress-track"
-                     role="progressbar"
-                     [attr.aria-valuenow]="percentFor(achievement)"
-                     aria-valuemin="0"
-                     aria-valuemax="100">
-                  <div class="progress-fill" [style.width.%]="percentFor(achievement)"></div>
-                </div>
-                <span class="progress-numbers">
-                  {{ progressFor(achievement).current }}/{{ progressFor(achievement).target }}
-                </span>
-              }
-            </div>
-          </div>
-        }
-      </section>
+            <span class="progress-numbers">
+              {{ progressFor(achievement).current }}/{{ progressFor(achievement).target }}
+            </span>
+          }
+        </div>
+      </div>
     }
-  </div>
-</ng-template>
+  </section>
+}

--- a/src/app/trainer-team/achievements/achievements.component.html
+++ b/src/app/trainer-team/achievements/achievements.component.html
@@ -32,25 +32,11 @@
         <h5 class="achievement-group-title">{{ groupLabelKey(group.group) | translate }}</h5>
 
         @for (achievement of group.achievements; track achievement.id) {
-          <div class="achievement-row"
-               [class.unlocked]="isUnlocked(achievement)"
-               [class.concealed]="isConcealed(achievement)">
+          <div class="achievement-row" [class.unlocked]="isUnlocked(achievement)">
 
             <div class="achievement-text">
-              <span class="achievement-name">
-                @if (isConcealed(achievement)) {
-                  ???
-                } @else {
-                  {{ nameKey(achievement) | translate }}
-                }
-              </span>
-              <span class="achievement-description">
-                @if (isConcealed(achievement)) {
-                  {{ 'achievementsScreen.hidden' | translate }}
-                } @else {
-                  {{ descriptionKey(achievement) | translate }}
-                }
-              </span>
+              <span class="achievement-name">{{ nameKey(achievement) | translate }}</span>
+              <span class="achievement-description">{{ descriptionKey(achievement) | translate }}</span>
             </div>
 
             <div class="achievement-progress">
@@ -64,11 +50,9 @@
                      aria-valuemax="100">
                   <div class="progress-fill" [style.width.%]="percentFor(achievement)"></div>
                 </div>
-                @if (!isConcealed(achievement)) {
-                  <span class="progress-numbers">
-                    {{ progressFor(achievement).current }}/{{ progressFor(achievement).target }}
-                  </span>
-                }
+                <span class="progress-numbers">
+                  {{ progressFor(achievement).current }}/{{ progressFor(achievement).target }}
+                </span>
               }
             </div>
           </div>

--- a/src/app/trainer-team/achievements/achievements.component.spec.ts
+++ b/src/app/trainer-team/achievements/achievements.component.spec.ts
@@ -73,22 +73,6 @@ describe('AchievementsComponent', () => {
     expect(component.percentFor(smell)).toBe(100);
   });
 
-  it('conceals a hidden achievement until it is earned', () => {
-    const stadium = ACHIEVEMENTS.find(a => a.id === 'pokemon_stadium')!;
-    expect(component.isConcealed(stadium)).toBeTrue();
-
-    TestBed.inject(StatsService).recordChampion(1, 3);
-    fixture.detectChanges();
-
-    expect(component.isConcealed(stadium))
-      .withContext('once earned there is nothing left to hide')
-      .toBeFalse();
-  });
-
-  it('does not conceal an ordinary locked achievement', () => {
-    expect(component.isConcealed(ACHIEVEMENTS.find(a => a.id === 'veteran')!)).toBeFalse();
-  });
-
   it('reports lifetime totals', () => {
     TestBed.inject(StatsService).increment('spins_total', 430);
     fixture.detectChanges();

--- a/src/app/trainer-team/achievements/achievements.component.ts
+++ b/src/app/trainer-team/achievements/achievements.component.ts
@@ -95,15 +95,6 @@ export class AchievementsComponent implements OnInit, OnDestroy {
     return achievement.id in this.unlocks;
   }
 
-  /**
-   * Hidden achievements stay nameless until earned, so there is something to
-   * discover — and so the three region-locked ones do not read as broken to
-   * someone who never visits those regions.
-   */
-  isConcealed(achievement: Achievement): boolean {
-    return achievement.hidden === true && !this.isUnlocked(achievement);
-  }
-
   nameKey(achievement: Achievement): string {
     return achievementNameKey(achievement.id);
   }

--- a/src/app/trainer-team/achievements/achievements.component.ts
+++ b/src/app/trainer-team/achievements/achievements.component.ts
@@ -1,7 +1,5 @@
-import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { NgIconsModule } from '@ng-icons/core';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Observable, Subscription } from 'rxjs';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -38,7 +36,7 @@ interface LifetimeTotal {
  */
 @Component({
   selector: 'app-achievements',
-  imports: [CommonModule, NgIconsModule, TranslatePipe],
+  imports: [CommonModule, TranslatePipe],
   templateUrl: './achievements.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './achievements.component.css',
@@ -47,14 +45,12 @@ export class AchievementsComponent implements OnInit, OnDestroy {
 
   constructor(
     private themeService: ThemeService,
-    private modalService: NgbModal,
     private achievementService: AchievementService,
     private statsService: StatsService,
     private pokedexService: PokedexService,
     private badgeDexService: BadgeDexService,
   ) {}
 
-  @ViewChild('achievementsModal', { static: true }) achievementsModal!: TemplateRef<unknown>;
 
   darkMode!: Observable<boolean>;
 
@@ -120,13 +116,7 @@ export class AchievementsComponent implements OnInit, OnDestroy {
     return `achievementsScreen.group.${group}`;
   }
 
-  openAchievements(): void {
-    this.modalService.open(this.achievementsModal, { centered: true, size: 'lg', scrollable: true });
-  }
 
-  closeModal(): void {
-    this.modalService.dismissAll();
-  }
 
   private buildTotals(): LifetimeTotal[] {
     const caught = this.pokedexService.currentPokedex.caught;

--- a/src/app/trainer-team/badge-dex/badge-dex.component.html
+++ b/src/app/trainer-team/badge-dex/badge-dex.component.html
@@ -1,51 +1,28 @@
-<button type="button" class="btn"
-  [ngClass]="(darkMode | async) ? 'btn-outline-light' : 'btn-outline-dark'"
-  (click)="openBadgeDex()">
-  <ng-icon name="bootstrapTrophy"></ng-icon>
-  {{ 'badgeDex.button' | translate }}
-</button>
+@for (region of cases; track region.generationId) {
+  <section class="region-case"
+           [class.current-region]="region.generationId === currentGenerationId"
+           [class.complete]="isRegionComplete(region)">
 
-<ng-template #badgeDexModal let-modal>
-  <div class="modal-header" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
-    <h4 class="modal-title">
-      {{ 'badgeDex.title' | translate }}
-      <small class="badge-dex-total">
-        {{ 'badgeDex.progress' | translate: { earned: earnedCount, total: totalBadges } }}
-      </small>
-    </h4>
-    <button type="button" class="btn-close"
-      [ngClass]="(darkMode | async) ? 'btn-close-white' : ''"
-      (click)="closeModal()" aria-label="Close"></button>
-  </div>
+    <header class="region-header">
+      <span class="region-name">{{ region.region }}</span>
+      <span class="region-count">{{ earnedInRegion(region) }}/{{ region.rounds.length }}</span>
+    </header>
 
-  <div class="modal-body" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
-    @for (region of cases; track region.generationId) {
-      <section class="region-case"
-               [class.current-region]="region.generationId === currentGenerationId"
-               [class.complete]="isRegionComplete(region)">
-
-        <header class="region-header">
-          <span class="region-name">{{ region.region }}</span>
-          <span class="region-count">{{ earnedInRegion(region) }}/{{ region.rounds.length }}</span>
-        </header>
-
-        <div class="badge-row">
-          @for (round of region.rounds; track $index) {
-            <div class="badge-round" [class.multi]="round.badges.length > 1">
-              @for (badge of round.badges; track badge.name) {
-                <img [src]="badge.sprite"
-                     appImageFallback
-                     loading="lazy"
-                     class="badge-sprite"
-                     [class.earned]="hasBadge(badge)"
-                     placement="bottom"
-                     [ngbTooltip]="hasBadge(badge) ? (badge.name | translate) : '???'"
-                     [alt]="hasBadge(badge) ? (badge.name | translate) : '???'">
-              }
-            </div>
+    <div class="badge-row">
+      @for (round of region.rounds; track $index) {
+        <div class="badge-round" [class.multi]="round.badges.length > 1">
+          @for (badge of round.badges; track badge.name) {
+            <img [src]="badge.sprite"
+                 appImageFallback
+                 loading="lazy"
+                 class="badge-sprite"
+                 [class.earned]="hasBadge(badge)"
+                 placement="bottom"
+                 [ngbTooltip]="hasBadge(badge) ? (badge.name | translate) : '???'"
+                 [alt]="hasBadge(badge) ? (badge.name | translate) : '???'">
           }
         </div>
-      </section>
-    }
-  </div>
-</ng-template>
+      }
+    </div>
+  </section>
+}

--- a/src/app/trainer-team/badge-dex/badge-dex.component.ts
+++ b/src/app/trainer-team/badge-dex/badge-dex.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { NgIconsModule } from '@ng-icons/core';
-import { NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { Observable, Subscription } from 'rxjs';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -32,7 +31,7 @@ interface RegionCase {
  */
 @Component({
   selector: 'app-badge-dex',
-  imports: [CommonModule, NgIconsModule, NgbTooltipModule, TranslatePipe, ImageFallbackDirective],
+  imports: [CommonModule, NgbTooltipModule, TranslatePipe, ImageFallbackDirective],
   templateUrl: './badge-dex.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './badge-dex.component.css',
@@ -41,14 +40,10 @@ export class BadgeDexComponent implements OnInit, OnDestroy {
 
   constructor(
     private themeService: ThemeService,
-    private modalService: NgbModal,
     private badgeDexService: BadgeDexService,
     private generationService: GenerationService,
   ) {}
 
-  // static: true, or the first click finds an undefined ref — same reason as
-  // the Pokédex modal next to it.
-  @ViewChild('badgeDexModal', { static: true }) badgeDexModal!: TemplateRef<unknown>;
 
   darkMode!: Observable<boolean>;
   earned: ReadonlySet<string> = new Set();
@@ -99,13 +94,7 @@ export class BadgeDexComponent implements OnInit, OnDestroy {
     return region.rounds.filter(round => round.badges.some(badge => this.hasBadge(badge))).length;
   }
 
-  openBadgeDex(): void {
-    this.modalService.open(this.badgeDexModal, { centered: true, size: 'lg', scrollable: true });
-  }
 
-  closeModal(): void {
-    this.modalService.dismissAll();
-  }
 
   private buildCases(): RegionCase[] {
     return this.generationService.getGenerationList().map(generation => ({

--- a/src/app/trainer-team/pokedex/pokedex.component.html
+++ b/src/app/trainer-team/pokedex/pokedex.component.html
@@ -1,43 +1,26 @@
-<button type="button" class="btn"
-  [ngClass]="(darkMode | async) ? 'btn-outline-light' : 'btn-outline-dark'"
-  (click)="openPokedex()">
-  <ng-icon name="bootstrapBook"></ng-icon>
-  {{ 'pokedex.button' | translate }}
-</button>
-
-<ng-template #pokedexModal let-modal>
-  <div class="modal-header" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
-    <h4 class="modal-title">{{ 'pokedex.title' | translate }}</h4>
-    <button type="button" class="btn-close"
-      [ngClass]="(darkMode | async) ? 'btn-close-white' : ''"
-      (click)="closeModal()" aria-label="Close"></button>
-  </div>
-  <div class="modal-body" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
-    <ul class="nav nav-tabs mb-2">
-      <li class="nav-item">
-        <button class="nav-link" [class.active]="activeTab === 'local'"
-                (click)="activeTab = 'local'">
-          {{ 'pokedex.tab.local' | translate: { region: currentRegion } }}
-        </button>
-      </li>
-      <li class="nav-item">
-        <button class="nav-link" [class.active]="activeTab === 'national'"
-                (click)="activeTab = 'national'">
-          {{ 'pokedex.tab.national' | translate }}
-        </button>
-      </li>
-    </ul>
-    <p class="mb-2">
-      {{ 'pokedex.caught' | translate }} {{ caughtCount }} / {{ totalCount }}
-    </p>
-    <div class="pokedex-grid">
-      @for (id of activeIds; track id) {
-        <app-pokedex-entry
-          [pokemonId]="id"
-          [entry]="pokedexData?.caught?.[id.toString()]"
-          (entryClicked)="onEntryClicked($event)">
-        </app-pokedex-entry>
-      }
-    </div>
-  </div>
-</ng-template>
+<ul class="nav nav-tabs mb-2">
+  <li class="nav-item">
+    <button class="nav-link" [class.active]="activeTab === 'local'"
+            (click)="activeTab = 'local'">
+      {{ 'pokedex.tab.local' | translate: { region: currentRegion } }}
+    </button>
+  </li>
+  <li class="nav-item">
+    <button class="nav-link" [class.active]="activeTab === 'national'"
+            (click)="activeTab = 'national'">
+      {{ 'pokedex.tab.national' | translate }}
+    </button>
+  </li>
+</ul>
+<p class="mb-2">
+  {{ 'pokedex.caught' | translate }} {{ caughtCount }} / {{ totalCount }}
+</p>
+<div class="pokedex-grid">
+  @for (id of activeIds; track id) {
+    <app-pokedex-entry
+      [pokemonId]="id"
+      [entry]="pokedexData?.caught?.[id.toString()]"
+      (entryClicked)="onEntryClicked($event)">
+    </app-pokedex-entry>
+  }
+</div>

--- a/src/app/trainer-team/pokedex/pokedex.component.spec.ts
+++ b/src/app/trainer-team/pokedex/pokedex.component.spec.ts
@@ -8,6 +8,7 @@ import { PokedexComponent } from './pokedex.component';
 import { PokedexService } from '../../services/pokedex-service/pokedex.service';
 import { GenerationService } from '../../services/generation-service/generation.service';
 import { PokemonService } from '../../services/pokemon-service/pokemon.service';
+import { PokemonItem } from '../../interfaces/pokemon-item';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PokedexDetailModalComponent } from '../../pokedex/pokedex-detail-modal/pokedex-detail-modal.component';
 
@@ -31,9 +32,14 @@ describe('PokedexComponent', () => {
     generationServiceSpy.getCurrentGeneration.and.returnValue(
       { id: 1, text: 'Gen 1', region: 'Kanto', fillStyle: 'darkred', weight: 1 }
     );
-    pokemonServiceSpy = jasmine.createSpyObj('PokemonService', [], {
-      nationalDexPokemon: [{ pokemonId: 1, text: 'pokemon.bulbasaur', fillStyle: 'green', sprite: null, shiny: false, power: 1, weight: 1 }]
+    const bulbasaur: PokemonItem = { pokemonId: 1, text: 'pokemon.bulbasaur', fillStyle: 'green', sprite: null, shiny: false, power: 1, weight: 1 };
+    // getPokemonById is needed now that the grid actually renders: this panel
+    // used to live inside an ng-template that a spec never instantiated, so
+    // its children were never built and the gap in this mock never showed.
+    pokemonServiceSpy = jasmine.createSpyObj('PokemonService', ['getPokemonById'], {
+      nationalDexPokemon: [bulbasaur]
     });
+    pokemonServiceSpy.getPokemonById.and.returnValue(bulbasaur);
     await TestBed.configureTestingModule({
       imports: [PokedexComponent],
       providers: [
@@ -71,14 +77,6 @@ describe('PokedexComponent', () => {
   it('caughtCount is 0 or more and not greater than totalCount', () => {
     expect(component.caughtCount).toBeGreaterThanOrEqual(0);
     expect(component.caughtCount).toBeLessThanOrEqual(component.totalCount);
-  });
-
-  it('openPokedex calls NgbModal.open with size lg', () => {
-    component.openPokedex();
-    expect(modalServiceSpy.open).toHaveBeenCalledWith(
-      jasmine.anything(),
-      jasmine.objectContaining({ size: 'lg' })
-    );
   });
 
   it('darkMode field is assigned after ngOnInit', () => {

--- a/src/app/trainer-team/pokedex/pokedex.component.ts
+++ b/src/app/trainer-team/pokedex/pokedex.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { NgIconsModule } from '@ng-icons/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Observable, Subscription } from 'rxjs';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -16,7 +15,7 @@ import { pokedexByGeneration } from '../../pokedex/pokedex-by-generation';
 
 @Component({
   selector: 'app-pokedex',
-  imports: [CommonModule, NgIconsModule, TranslatePipe, PokedexEntryComponent],
+  imports: [CommonModule, TranslatePipe, PokedexEntryComponent],
   templateUrl: './pokedex.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './pokedex.component.css'
@@ -31,8 +30,6 @@ export class PokedexComponent implements OnInit, OnDestroy {
     private pokemonService: PokemonService
   ) {}
 
-  // Omitting static: true causes openPokedex() to fail with undefined ref on first click
-  @ViewChild('pokedexModal', { static: true }) pokedexModal!: TemplateRef<any>;
 
   darkMode!: Observable<boolean>;
   pokedexData: PokedexData | undefined;
@@ -61,17 +58,7 @@ export class PokedexComponent implements OnInit, OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-  openPokedex(): void {
-    this.activeTab = 'local';  // per D-03: Local Dex active by default on open
-    this.modalService.open(this.pokedexModal, {
-      centered: true,
-      size: 'lg'
-    });
-  }
 
-  closeModal(): void {
-    this.modalService.dismissAll();
-  }
 
   onEntryClicked(event: PokedexEntryClickEvent): void {
     const modalRef = this.modalService.open(PokedexDetailModalComponent, {

--- a/src/app/trainer-team/rotom-phone/rotom-phone.component.css
+++ b/src/app/trainer-team/rotom-phone/rotom-phone.component.css
@@ -1,0 +1,27 @@
+/*
+ * The tab strip is the phone's home screen, and all three apps have to be
+ * visible at 375px.
+ *
+ * A horizontally scrolling strip was the first attempt and it hid
+ * "Achievements" off the right edge with nothing to say it was there — on a
+ * phone that is the same as not shipping it. Wrapping to a second row is
+ * uglier and keeps every app findable, which is the trade worth making.
+ */
+.phone-apps {
+  flex-wrap: wrap;
+}
+
+.phone-apps .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+}
+
+/* The icons are decoration next to a label that already says the word. They
+   are the first thing to go when the row is tight. */
+@media (max-width: 460px) {
+  .phone-apps .nav-link ng-icon {
+    display: none;
+  }
+}

--- a/src/app/trainer-team/rotom-phone/rotom-phone.component.html
+++ b/src/app/trainer-team/rotom-phone/rotom-phone.component.html
@@ -1,0 +1,47 @@
+<button type="button" class="btn"
+  [ngClass]="(darkMode | async) ? 'btn-outline-light' : 'btn-outline-dark'"
+  (click)="open()">
+  <ng-icon name="bootstrapPhone"></ng-icon>
+  {{ 'rotomPhone.button' | translate }}
+</button>
+
+<ng-template #phoneModal let-modal>
+  <div class="modal-header" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
+    <h4 class="modal-title">{{ 'rotomPhone.title' | translate }}</h4>
+    <button type="button" class="btn-close"
+      [ngClass]="(darkMode | async) ? 'btn-close-white' : ''"
+      (click)="closeModal()" aria-label="Close"></button>
+  </div>
+
+  <div class="modal-body" [ngClass]="(darkMode | async) ? 'bg-dark text-white' : ''">
+    <ul class="nav nav-tabs mb-3 phone-apps">
+      <li class="nav-item">
+        <button class="nav-link" [class.active]="app === 'pokedex'" (click)="app = 'pokedex'">
+          <ng-icon name="bootstrapBook"></ng-icon> {{ 'pokedex.title' | translate }}
+        </button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" [class.active]="app === 'badges'" (click)="app = 'badges'">
+          <ng-icon name="bootstrapTrophy"></ng-icon> {{ 'badgeDex.title' | translate }}
+        </button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" [class.active]="app === 'achievements'" (click)="app = 'achievements'">
+          <ng-icon name="bootstrapAward"></ng-icon> {{ 'achievementsScreen.title' | translate }}
+        </button>
+      </li>
+    </ul>
+
+    <!-- @if rather than hiding with CSS: each panel subscribes to a service
+         and builds a grid of up to 1,025 entries, and three of those mounted
+         at once for the sake of an instant tab switch is not a good trade on
+         a phone. -->
+    @if (app === 'pokedex') {
+      <app-pokedex></app-pokedex>
+    } @else if (app === 'badges') {
+      <app-badge-dex></app-badge-dex>
+    } @else {
+      <app-achievements></app-achievements>
+    }
+  </div>
+</ng-template>

--- a/src/app/trainer-team/rotom-phone/rotom-phone.component.ts
+++ b/src/app/trainer-team/rotom-phone/rotom-phone.component.ts
@@ -1,0 +1,63 @@
+import { Component, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgIconsModule } from '@ng-icons/core';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Observable } from 'rxjs';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { ThemeService } from '../../services/theme-service/theme.service';
+import { PokedexComponent } from '../pokedex/pokedex.component';
+import { BadgeDexComponent } from '../badge-dex/badge-dex.component';
+import { AchievementsComponent } from '../achievements/achievements.component';
+
+type PhoneApp = 'pokedex' | 'badges' | 'achievements';
+
+/**
+ * One button for everything the player has collected.
+ *
+ * The Pokédex, the trophy case and the achievements were three buttons in a
+ * row that only ever grew, next to the PC. They are the same kind of thing —
+ * a record of what you have done — so they belong behind one door, and the
+ * row is now the two it should always have been: storage on the left, this on
+ * the right.
+ *
+ * Named for the Rotom Phone, which in Sword and Shield is exactly this: one
+ * device holding the Pokédex and everything adjacent to it.
+ */
+@Component({
+  selector: 'app-rotom-phone',
+  imports: [CommonModule, NgIconsModule, TranslatePipe, PokedexComponent, BadgeDexComponent, AchievementsComponent],
+  templateUrl: './rotom-phone.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  styleUrl: './rotom-phone.component.css',
+})
+export class RotomPhoneComponent {
+
+  constructor(
+    private themeService: ThemeService,
+    private modalService: NgbModal,
+  ) {
+    this.darkMode = this.themeService.isDark$;
+  }
+
+  // static: true, or the first click finds an undefined ref — the same reason
+  // the three panels this replaced each said so.
+  @ViewChild('phoneModal', { static: true }) phoneModal!: TemplateRef<unknown>;
+
+  // Assigned in the constructor body, not as a field initialiser: those run
+  // before constructor parameter properties exist, and this codebase has been
+  // bitten by that before.
+  readonly darkMode: Observable<boolean>;
+
+  /** The Pokédex is what people open this for. */
+  app: PhoneApp = 'pokedex';
+
+  open(): void {
+    this.app = 'pokedex';
+    this.modalService.open(this.phoneModal, { centered: true, size: 'lg', scrollable: true });
+  }
+
+  closeModal(): void {
+    this.modalService.dismissAll();
+  }
+}

--- a/src/app/trainer-team/trainer-team.component.html
+++ b/src/app/trainer-team/trainer-team.component.html
@@ -45,9 +45,7 @@
                </div>
                <div class="col-12 p-0 d-flex flex-column flex-md-row gap-2">
                     <app-storage-pc></app-storage-pc>
-                    <app-pokedex></app-pokedex>
-                    <app-badge-dex></app-badge-dex>
-                    <app-achievements></app-achievements>
+                    <app-rotom-phone></app-rotom-phone>
                </div>
           </div>
     </div>

--- a/src/app/trainer-team/trainer-team.component.ts
+++ b/src/app/trainer-team/trainer-team.component.ts
@@ -12,8 +12,8 @@ import { PokedexComponent } from "./pokedex/pokedex.component";
 import { BadgeDexComponent } from "./badge-dex/badge-dex.component";
 import { AchievementsComponent } from "./achievements/achievements.component";
 import {TranslatePipe} from '@ngx-translate/core';
-import { ItemItem } from '../interfaces/item-item';
 import { ImageFallbackDirective } from '../directives/image-fallback.directive';
+import { MegaStoneActivation } from '../services/mega-stone-service/mega-stone.service';
 
 @Component({
   selector: 'app-trainer-team',
@@ -36,7 +36,7 @@ export class TrainerTeamComponent implements OnInit, OnDestroy {
   trainerBadges!: Badge[];
 
   darkMode!: Observable<boolean>;
-  @Output() megaStoneInterrupt = new EventEmitter<ItemItem>();
+  @Output() megaStoneInterrupt = new EventEmitter<MegaStoneActivation>();
 
   private trainerSubscription!: Subscription;
   private teamSubscription!: Subscription;
@@ -86,7 +86,7 @@ export class TrainerTeamComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.megaStoneInterrupt.emit(megaStone);
+    this.megaStoneInterrupt.emit({ stone: megaStone, pokemon });
   }
 
   private getHeldMegaStoneItem(pokemon: PokemonItem | undefined) {

--- a/src/app/trainer-team/trainer-team.component.ts
+++ b/src/app/trainer-team/trainer-team.component.ts
@@ -8,9 +8,7 @@ import { BadgesComponent } from "./badges/badges.component";
 import { Badge } from '../interfaces/badge';
 import { TrainerService } from '../services/trainer-service/trainer.service';
 import { StoragePcComponent } from "./storage-pc/storage-pc.component";
-import { PokedexComponent } from "./pokedex/pokedex.component";
-import { BadgeDexComponent } from "./badge-dex/badge-dex.component";
-import { AchievementsComponent } from "./achievements/achievements.component";
+import { RotomPhoneComponent } from "./rotom-phone/rotom-phone.component";
 import {TranslatePipe} from '@ngx-translate/core';
 import { ImageFallbackDirective } from '../directives/image-fallback.directive';
 import { MegaStoneActivation } from '../services/mega-stone-service/mega-stone.service';
@@ -21,7 +19,10 @@ import { MegaStoneActivation } from '../services/mega-stone-service/mega-stone.s
     ImageFallbackDirective,CommonModule,
     NgbTooltipModule,
     BadgesComponent,
-    StoragePcComponent, TranslatePipe, PokedexComponent, BadgeDexComponent, AchievementsComponent],
+    StoragePcComponent,
+    RotomPhoneComponent,
+    TranslatePipe,
+  ],
   templateUrl: './trainer-team.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrls: ['./trainer-team.component.css']

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3087,7 +3087,9 @@
       "retry": "Jetzt versuchen"
     },
     "signOutUnsyncedWarning": "Ein Teil deines Fortschritts hat dein Konto noch nicht erreicht, und das Abmelden löscht dieses Gerät. Dieser Fortschritt geht verloren.",
-    "signOutAnyway": "Trotzdem abmelden"
+    "signOutAnyway": "Trotzdem abmelden",
+    "confirmPassword": "Passwort bestätigen",
+    "passwordMismatch": "Die beiden Passwörter stimmen nicht überein."
   },
   "detail": {
     "name": "Name",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -258,7 +258,7 @@
             "findFossil": "Finde ein Fossil",
             "battleRival": "Rivalen-Kampf",
             "safariZone": "Besuche die Safari-Zone",
-            "friendSafari": "Betritt eine Freundes-Safari",
+            "friendSafari": "Freundes-Safari",
             "areaZero": "Erkunde Zone Null"
           }
         },
@@ -2836,7 +2836,6 @@
     "button": "Erfolge",
     "title": "Erfolge",
     "unlocked": "Erfolg freigeschaltet",
-    "hidden": "Noch ein Geheimnis.",
     "group": {
       "collection": "Sammlung",
       "shiny": "Schillernd",
@@ -3076,7 +3075,13 @@
     "cancel": "Abbrechen",
     "deleteWarning": "Damit werden dein Konto und alle Inhalte endgültig gelöscht. Gib zur Bestätigung dein Passwort ein.",
     "error": {
-      "generic": "Das hat nicht geklappt. Bitte versuche es erneut."
+      "generic": "Das hat nicht geklappt. Bitte versuche es erneut.",
+      "credentials": "Diese E-Mail und dieses Passwort gehören zu keinem Konto.",
+      "emailTaken": "Es gibt bereits ein Konto mit dieser E-Mail. Melde dich stattdessen an.",
+      "rateLimited": "Zu viele Versuche. Warte einen Moment und versuche es erneut.",
+      "invalid": "Überprüfe deine Eingaben und versuche es erneut.",
+      "server": "Bei uns ist etwas schiefgelaufen. Versuche es erneut.",
+      "offline": "Der Server war nicht erreichbar. Prüfe deine Verbindung und versuche es erneut."
     },
     "sync": {
       "off": "Keine Synchronisierung.",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2820,7 +2820,6 @@
   },
   "pokedex": {
     "title": "Pokédex",
-    "button": "Pokédex",
     "tab": {
       "local": "{{region}}-Pokédex",
       "national": "Nationaler Pokédex"
@@ -2828,12 +2827,10 @@
     "caught": "Gefangen:"
   },
   "badgeDex": {
-    "button": "Orden",
     "title": "Ordensetui",
     "progress": "{{earned}} von {{total}}"
   },
   "achievementsScreen": {
-    "button": "Erfolge",
     "title": "Erfolge",
     "unlocked": "Erfolg freigeschaltet",
     "group": {
@@ -3134,5 +3131,9 @@
   "migration": {
     "transferred": "Dein Fortschritt ist angekommen — {{count}} Pokémon sind zurück in deinem Pokédex.",
     "dismiss": "Schließen"
+  },
+  "rotomPhone": {
+    "button": "Rotom-Smartphone",
+    "title": "Rotom-Smartphone"
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2820,7 +2820,6 @@
   },
   "pokedex": {
     "title": "Pokédex",
-    "button": "Pokédex",
     "tab": {
       "local": "{{region}} Dex",
       "national": "National Dex"
@@ -2828,12 +2827,10 @@
     "caught": "Caught:"
   },
   "badgeDex": {
-    "button": "Badges",
     "title": "Badge Case",
     "progress": "{{earned}} of {{total}}"
   },
   "achievementsScreen": {
-    "button": "Achievements",
     "title": "Achievements",
     "unlocked": "Achievement unlocked",
     "group": {
@@ -3134,5 +3131,9 @@
   "migration": {
     "transferred": "Your progress arrived — {{count}} Pokémon are back in your Pokédex.",
     "dismiss": "Dismiss"
+  },
+  "rotomPhone": {
+    "button": "Rotom Phone",
+    "title": "Rotom Phone"
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3087,7 +3087,9 @@
       "retry": "Try now"
     },
     "signOutUnsyncedWarning": "Some progress has not reached your account yet, and signing out clears this device. That progress will be lost.",
-    "signOutAnyway": "Sign out anyway"
+    "signOutAnyway": "Sign out anyway",
+    "confirmPassword": "Confirm password",
+    "passwordMismatch": "The two passwords do not match."
   },
   "detail": {
     "name": "Name",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -258,7 +258,7 @@
             "findFossil": "Find a Fossil",
             "battleRival": "Battle Rival",
             "safariZone": "Visit the Safari Zone",
-            "friendSafari": "Enter a Friend Safari",
+            "friendSafari": "Friend Safari",
             "areaZero": "Explore Area Zero"
           }
         },
@@ -2836,7 +2836,6 @@
     "button": "Achievements",
     "title": "Achievements",
     "unlocked": "Achievement unlocked",
-    "hidden": "A secret, for now.",
     "group": {
       "collection": "Collection",
       "shiny": "Shiny",
@@ -3076,7 +3075,13 @@
     "cancel": "Cancel",
     "deleteWarning": "This deletes your account and everything in it, permanently. Enter your password to confirm.",
     "error": {
-      "generic": "That did not work. Please try again."
+      "generic": "That did not work. Please try again.",
+      "credentials": "That email and password do not match an account.",
+      "emailTaken": "An account with that email already exists. Sign in instead.",
+      "rateLimited": "Too many attempts. Please wait a moment and try again.",
+      "invalid": "Please check what you typed and try again.",
+      "server": "Something went wrong on our end. Please try again.",
+      "offline": "Could not reach the server. Check your connection and try again."
     },
     "sync": {
       "off": "Not syncing.",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -258,12 +258,12 @@
             "findFossil": "Encontrar un fósil",
             "battleRival": "Combate contra el Rival",
             "safariZone": "Visitar la Zona Safari",
-            "friendSafari": "Entrar en una Safari Amigo",
+            "friendSafari": "Safari Amistad",
             "areaZero": "Explorar el Área Cero"
           }
         },
         "friendSafari": {
-          "which": "¿Qué Safari Amigo?",
+          "which": "¿Qué Safari Amistad?",
           "catch": "¿Qué Pokémon vas a capturar?"
         },
         "safariZone": {
@@ -2836,7 +2836,6 @@
     "button": "Logros",
     "title": "Logros",
     "unlocked": "Logro desbloqueado",
-    "hidden": "Un secreto, por ahora.",
     "group": {
       "collection": "Colección",
       "shiny": "Shiny",
@@ -3002,7 +3001,7 @@
     },
     "friend_code": {
       "name": "Código de Amigo",
-      "description": "Visita la Zona Safari Amigo."
+      "description": "Visita el Safari Amistad."
     },
     "the_great_crater": {
       "name": "El Gran Cráter",
@@ -3076,7 +3075,13 @@
     "cancel": "Cancelar",
     "deleteWarning": "Esto elimina tu cuenta y todo su contenido, de forma permanente. Escribe tu contraseña para confirmar.",
     "error": {
-      "generic": "No ha funcionado. Inténtalo de nuevo."
+      "generic": "No ha funcionado. Inténtalo de nuevo.",
+      "credentials": "Ese correo y contraseña no coinciden con ninguna cuenta.",
+      "emailTaken": "Ya existe una cuenta con ese correo. Inicia sesión.",
+      "rateLimited": "Demasiados intentos. Espera un momento e inténtalo de nuevo.",
+      "invalid": "Revisa lo que escribiste e inténtalo de nuevo.",
+      "server": "Algo salió mal de nuestro lado. Inténtalo de nuevo.",
+      "offline": "No se pudo contactar con el servidor. Comprueba tu conexión e inténtalo de nuevo."
     },
     "sync": {
       "off": "Sin sincronizar.",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3087,7 +3087,9 @@
       "retry": "Intentar ahora"
     },
     "signOutUnsyncedWarning": "Parte de tu progreso aún no ha llegado a tu cuenta, y cerrar sesión borra este dispositivo. Ese progreso se perderá.",
-    "signOutAnyway": "Cerrar sesión de todos modos"
+    "signOutAnyway": "Cerrar sesión de todos modos",
+    "confirmPassword": "Confirmar contraseña",
+    "passwordMismatch": "Las dos contraseñas no coinciden."
   },
   "detail": {
     "name": "Nombre",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2820,7 +2820,6 @@
   },
   "pokedex": {
     "title": "Pokédex",
-    "button": "Pokédex",
     "tab": {
       "local": "Pokédex {{region}}",
       "national": "Pokédex Nacional"
@@ -2828,12 +2827,10 @@
     "caught": "Capturados:"
   },
   "badgeDex": {
-    "button": "Medallas",
     "title": "Estuche de Medallas",
     "progress": "{{earned}} de {{total}}"
   },
   "achievementsScreen": {
-    "button": "Logros",
     "title": "Logros",
     "unlocked": "Logro desbloqueado",
     "group": {
@@ -3134,5 +3131,9 @@
   "migration": {
     "transferred": "Tu progreso ha llegado: {{count}} Pokémon están de vuelta en tu Pokédex.",
     "dismiss": "Cerrar"
+  },
+  "rotomPhone": {
+    "button": "Rotom Phone",
+    "title": "Rotom Phone"
   }
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -3087,7 +3087,9 @@
       "retry": "Réessayer maintenant"
     },
     "signOutUnsyncedWarning": "Une partie de votre progression n'a pas encore atteint votre compte, et la déconnexion efface cet appareil. Cette progression sera perdue.",
-    "signOutAnyway": "Se déconnecter quand même"
+    "signOutAnyway": "Se déconnecter quand même",
+    "confirmPassword": "Confirmer le mot de passe",
+    "passwordMismatch": "Les deux mots de passe ne correspondent pas."
   },
   "detail": {
     "name": "Nom",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -2820,7 +2820,6 @@
   },
   "pokedex": {
     "title": "Pokédex",
-    "button": "Pokédex",
     "tab": {
       "local": "Pokédex {{region}}",
       "national": "Pokédex National"
@@ -2828,12 +2827,10 @@
     "caught": "Capturés :"
   },
   "badgeDex": {
-    "button": "Badges",
     "title": "Boîte à Badges",
     "progress": "{{earned}} sur {{total}}"
   },
   "achievementsScreen": {
-    "button": "Succès",
     "title": "Succès",
     "unlocked": "Succès débloqué",
     "group": {
@@ -3134,5 +3131,9 @@
   "migration": {
     "transferred": "Votre progression est arrivée — {{count}} Pokémon sont de retour dans votre Pokédex.",
     "dismiss": "Fermer"
+  },
+  "rotomPhone": {
+    "button": "Rotom Phone",
+    "title": "Rotom Phone"
   }
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -258,12 +258,12 @@
             "findFossil": "Trouver un fossile",
             "battleRival": "Combattre le rival",
             "safariZone": "Visiter le Parc Safari",
-            "friendSafari": "Entrer dans une Safari des Amis",
+            "friendSafari": "Safari des Amis",
             "areaZero": "Explorer la Zone Zéro"
           }
         },
         "friendSafari": {
-          "which": "Quelle Safari des Amis ?",
+          "which": "Quel Safari des Amis ?",
           "catch": "Quel Pokémon allez-vous capturer ?"
         },
         "safariZone": {
@@ -2836,7 +2836,6 @@
     "button": "Succès",
     "title": "Succès",
     "unlocked": "Succès débloqué",
-    "hidden": "Un secret, pour l’instant.",
     "group": {
       "collection": "Collection",
       "shiny": "Chromatiques",
@@ -3076,7 +3075,13 @@
     "cancel": "Annuler",
     "deleteWarning": "Ceci supprime votre compte et tout son contenu, définitivement. Saisissez votre mot de passe pour confirmer.",
     "error": {
-      "generic": "Cela n'a pas fonctionné. Veuillez réessayer."
+      "generic": "Cela n'a pas fonctionné. Veuillez réessayer.",
+      "credentials": "Cet e-mail et ce mot de passe ne correspondent à aucun compte.",
+      "emailTaken": "Un compte existe déjà avec cet e-mail. Connectez-vous.",
+      "rateLimited": "Trop de tentatives. Patientez un instant et réessayez.",
+      "invalid": "Vérifiez ce que vous avez saisi et réessayez.",
+      "server": "Un problème est survenu de notre côté. Réessayez.",
+      "offline": "Impossible de joindre le serveur. Vérifiez votre connexion et réessayez."
     },
     "sync": {
       "off": "Pas de synchronisation.",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3087,7 +3087,9 @@
       "retry": "Riprova ora"
     },
     "signOutUnsyncedWarning": "Una parte dei tuoi progressi non ha ancora raggiunto il tuo account, e disconnettersi cancella questo dispositivo. Quei progressi andranno persi.",
-    "signOutAnyway": "Disconnetti comunque"
+    "signOutAnyway": "Disconnetti comunque",
+    "confirmPassword": "Conferma password",
+    "passwordMismatch": "Le due password non coincidono."
   },
   "detail": {
     "name": "Nome",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -258,7 +258,7 @@
             "findFossil": "Trova un fossile",
             "battleRival": "Lotta contro il rivale",
             "safariZone": "Visita la Zona Safari",
-            "friendSafari": "Entra in un Safari degli Amici",
+            "friendSafari": "Safari degli Amici",
             "areaZero": "Esplora Area Zero"
           }
         },
@@ -2836,7 +2836,6 @@
     "button": "Obiettivi",
     "title": "Obiettivi",
     "unlocked": "Obiettivo sbloccato",
-    "hidden": "Un segreto, per ora.",
     "group": {
       "collection": "Collezione",
       "shiny": "Shiny",
@@ -3076,7 +3075,13 @@
     "cancel": "Annulla",
     "deleteWarning": "Questo elimina il tuo account e tutto il suo contenuto, definitivamente. Inserisci la password per confermare.",
     "error": {
-      "generic": "Non ha funzionato. Riprova."
+      "generic": "Non ha funzionato. Riprova.",
+      "credentials": "Questa email e questa password non corrispondono a nessun account.",
+      "emailTaken": "Esiste già un account con questa email. Accedi invece.",
+      "rateLimited": "Troppi tentativi. Aspetta un momento e riprova.",
+      "invalid": "Controlla quello che hai scritto e riprova.",
+      "server": "Qualcosa è andato storto da parte nostra. Riprova.",
+      "offline": "Impossibile raggiungere il server. Controlla la connessione e riprova."
     },
     "sync": {
       "off": "Nessuna sincronizzazione.",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2820,7 +2820,6 @@
   },
   "pokedex": {
     "title": "Pokédex",
-    "button": "Pokédex",
     "tab": {
       "local": "Pokédex {{region}}",
       "national": "Pokédex Nazionale"
@@ -2828,12 +2827,10 @@
     "caught": "Catturati:"
   },
   "badgeDex": {
-    "button": "Medaglie",
     "title": "Custodia Medaglie",
     "progress": "{{earned}} su {{total}}"
   },
   "achievementsScreen": {
-    "button": "Obiettivi",
     "title": "Obiettivi",
     "unlocked": "Obiettivo sbloccato",
     "group": {
@@ -3134,5 +3131,9 @@
   "migration": {
     "transferred": "I tuoi progressi sono arrivati: {{count}} Pokémon sono di nuovo nel tuo Pokédex.",
     "dismiss": "Chiudi"
+  },
+  "rotomPhone": {
+    "button": "Rotom Phone",
+    "title": "Rotom Phone"
   }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -258,12 +258,12 @@
             "findFossil": "Encontrar um Fóssil",
             "battleRival": "Batalha contra o Rival",
             "safariZone": "Visitar a Zona Safári",
-            "friendSafari": "Entrar em um Safári dos Amigos",
+            "friendSafari": "Friend Safari",
             "areaZero": "Explorar a Área Zero"
           }
         },
         "friendSafari": {
-          "which": "Qual Safári dos Amigos?",
+          "which": "Qual Friend Safari?",
           "catch": "Qual Pokémon você vai capturar?"
         },
         "safariZone": {
@@ -2836,7 +2836,6 @@
     "button": "Conquistas",
     "title": "Conquistas",
     "unlocked": "Conquista desbloqueada",
-    "hidden": "Um segredo, por enquanto.",
     "group": {
       "collection": "Coleção",
       "shiny": "Shiny",
@@ -3002,7 +3001,7 @@
     },
     "friend_code": {
       "name": "Código de Amigo",
-      "description": "Visite o Safári dos Amigos."
+      "description": "Visite o Friend Safari."
     },
     "the_great_crater": {
       "name": "A Grande Cratera",
@@ -3076,7 +3075,13 @@
     "cancel": "Cancelar",
     "deleteWarning": "Isso exclui sua conta e tudo nela, permanentemente. Digite sua senha para confirmar.",
     "error": {
-      "generic": "Não funcionou. Tente novamente."
+      "generic": "Não funcionou. Tente novamente.",
+      "credentials": "Esse email e senha não correspondem a nenhuma conta.",
+      "emailTaken": "Já existe uma conta com esse email. Entre nela.",
+      "rateLimited": "Muitas tentativas. Espere um momento e tente de novo.",
+      "invalid": "Confira o que você digitou e tente de novo.",
+      "server": "Algo deu errado do nosso lado. Tente de novo.",
+      "offline": "Não foi possível falar com o servidor. Verifique sua conexão e tente de novo."
     },
     "sync": {
       "off": "Sem sincronização.",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3087,7 +3087,9 @@
       "retry": "Tentar agora"
     },
     "signOutUnsyncedWarning": "Parte do seu progresso ainda não chegou à sua conta, e sair apaga este dispositivo. Esse progresso será perdido.",
-    "signOutAnyway": "Sair mesmo assim"
+    "signOutAnyway": "Sair mesmo assim",
+    "confirmPassword": "Confirmar senha",
+    "passwordMismatch": "As duas senhas não coincidem."
   },
   "detail": {
     "name": "Nome",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2820,7 +2820,6 @@
   },
   "pokedex": {
     "title": "Pokédex",
-    "button": "Pokédex",
     "tab": {
       "local": "Pokédex {{region}}",
       "national": "Pokédex Nacional"
@@ -2828,12 +2827,10 @@
     "caught": "Capturados:"
   },
   "badgeDex": {
-    "button": "Insígnias",
     "title": "Estojo de Insígnias",
     "progress": "{{earned}} de {{total}}"
   },
   "achievementsScreen": {
-    "button": "Conquistas",
     "title": "Conquistas",
     "unlocked": "Conquista desbloqueada",
     "group": {
@@ -3134,5 +3131,9 @@
   "migration": {
     "transferred": "Seu progresso chegou — {{count}} Pokémon estão de volta na sua Pokédex.",
     "dismiss": "Fechar"
+  },
+  "rotomPhone": {
+    "button": "Rotom Phone",
+    "title": "Rotom Phone"
   }
 }


### PR DESCRIPTION
**524/524 tests**, i18n parity at **2,385**. Stacked on #76.

The row under the team was four buttons and only ever grew. Three of them — Pokédex, trophy case, achievements — are the same kind of thing, *a record of what you have done*, so they now sit behind one door. The row is the two it should always have been:

> `[ Access PC ]  [ Rotom Phone ]`

## On the name

It's spelled **Rotom Phone** — the Sword/Shield device that holds the Pokédex, map, camera and League Card. Your instinct was right; it's the in-universe answer to "many features behind one button."

The alternative I considered was **Rotom Dex** (Sun/Moon), elegant because in-universe it literally *is* a Pokédex possessed by Rotom, so it isn't a metaphor for the grouping — it's the thing itself. But it names only one of the three. German gets "Rotom-Smartphone", which is that region's name for it.

## What moved

Each panel owned a button, a modal, a header and a close control. They keep their content and lose all four; the phone owns the chrome and switches with tabs.

**Only the active panel is mounted.** Each subscribes to a service and the Pokédex builds a grid of up to 1,025 entries — three of those alive at once isn't worth an instant tab switch on a phone.

## Two things this turned up

**The tab strip hid a whole feature on mobile.** My first attempt scrolled horizontally, which put "Achievements" off the right edge at 375px with nothing to indicate it was there — on a phone that's the same as not shipping it. It now wraps to a second row and drops the icons when tight; the icons are decoration next to a label that already says the word. Verified: 375px → two rows, all three visible, no scroll. 1280px → one row, icons shown.

**A spec had a mock that had never been exercised.** `PokedexComponent`'s `PokemonService` stub was missing `getPokemonById`, and nothing noticed because the grid lived inside an `ng-template` that no spec ever instantiated. Now the children really render and the gap showed immediately. That's a small argument that this structure is better tested than the one it replaced.

## Verified live

All three tabs open and mount correctly, and the achievements panel shows **50 rows, 0 concealed, 0 "???"** — which is the previous PR's un-hiding confirmed in the browser rather than just in a diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)