### PR TITLE
Em dashes the sweep missed

### DIFF
--- a/deploy/cloudflare-pages.md
+++ b/deploy/cloudflare-pages.md
@@ -1,6 +1,6 @@
 # Deploying the game to Cloudflare Pages
 
-`pokemon-roulette.zeroxm.com.br` is served by **Cloudflare Pages**, by Direct Upload — Cloudflare
+`pokemon-roulette.zeroxm.com.br` is served by **Cloudflare Pages**, by Direct Upload: Cloudflare
 has no access to the repository. The interim copy on automaton is gone; the **API stays on
 automaton**, because it is not a static site and Pages cannot host it.
 
@@ -47,7 +47,7 @@ source ~/.config/pokemon-roulette/cloudflare.env
 ./scripts/deploy-cloudflare.sh
 ```
 
-That publishes to a `*.pages.dev` URL. **Open it and check the game works there** — the point of
+That publishes to a `*.pages.dev` URL. **Open it and check the game works there**: the point of
 doing this before the DNS change is that the old deployment keeps serving players while you look.
 
 One limit to know about: **`*.pages.dev` cannot test anything account-shaped.** The API's CORS
@@ -66,14 +66,14 @@ Cloudflare dashboard → **Workers & Pages → pokemon-roulette → Custom domai
 domain** → `pokemon-roulette.zeroxm.com.br`.
 
 Cloudflare repoints the DNS record itself. **It will conflict with the existing record**, which
-today sends that hostname down the tunnel — accept the replacement.
+today sends that hostname down the tunnel: accept the replacement.
 
 ### 5. Remove the tunnel route
 
 Cloudflare dashboard → **Zero Trust → Networks → Tunnels** → your tunnel → **Public hostnames** →
 delete the entry for `pokemon-roulette.zeroxm.com.br`.
 
-Leave `pokemon-roulette-api.zeroxm.com.br` alone. **The API stays on automaton** — it is not a
+Leave `pokemon-roulette-api.zeroxm.com.br` alone. **The API stays on automaton**: it is not a
 static site and Pages cannot host it.
 
 ### 6. Stop the container
@@ -82,7 +82,7 @@ static site and Pages cannot host it.
 ssh automaton 'cd ~/apps/pokemon-roulette-web && docker compose down'
 ```
 
-Done, and the stack directory and images were removed with it — Pages is now the only host for this
+Done, and the stack directory and images were removed with it: Pages is now the only host for this
 hostname, so a stopped container with a live Traefik host rule was a surprise waiting to happen.
 Rebuilding it is `docker build` plus the deploy skill, not `docker compose up`.
 
@@ -94,9 +94,9 @@ The script builds, checks two things that would otherwise fail silently, and pub
 
 **What it checks, and why those two:**
 
-- **`<base href="/">`** — building with `--base-href=/pokemon-roulette/` by mistake produces a page
+- **`<base href="/">`**: building with `--base-href=/pokemon-roulette/` by mistake produces a page
   that loads and then 404s every asset. It looks like a broken CDN rather than a wrong build flag.
-- **`_redirects` and `_headers` reached the output** — without `_redirects`, every client-side route
+- **`_redirects` and `_headers` reached the output**: without `_redirects`, every client-side route
   (`/settings`, `/credits`) is a 404 on a reload or a shared link.
 
 It also deploys with `--branch main`, which is what makes a deployment **production**. Any other
@@ -107,9 +107,9 @@ branch name publishes a preview URL, which is a quiet way to deploy nothing.
 ## What does not change
 
 **GitHub Pages keeps serving the old URL either way.** Moving to Cloudflare Pages is not the
-migration cutover — that is #59, and it comes only after UAT (#60). Until then existing players stay
+migration cutover: that is #59, and it comes only after UAT (#60). Until then existing players stay
 on `zeroxm.github.io/pokemon-roulette/` with their Pokédex intact.
 
 **Never add a `CNAME` file to this repo.** GitHub Pages would then 301 the old URL to the custom
-domain, and that redirect happens before any JavaScript can run — destroying the only path by which
+domain, and that redirect happens before any JavaScript can run: destroying the only path by which
 an existing player's `localStorage` can ever be read.

--- a/handoff/index.html
+++ b/handoff/index.html
@@ -33,7 +33,7 @@
   <h1>Pokémon Roulette has a new address</h1>
   <p>The game now lives at <strong>pokemon-roulette.zeroxm.com.br</strong>.</p>
   <p id="found">Checking this browser for saved progress…</p>
-  <p>Your Pokédex is stored by your browser, and it is tied to this address — so it does not follow you automatically. This page can carry it across.</p>
+  <p>Your Pokédex is stored by your browser, and it is tied to this address, so it does not follow you automatically. This page can carry it across.</p>
 
   <div class="actions">
     <a id="transfer" class="primary" href="https://pokemon-roulette.zeroxm.com.br">Transfer my progress</a>
@@ -41,7 +41,7 @@
   </div>
 
   <p class="note">Your progress travels in the link itself and is never sent to a server. Nothing here is stored or shared, and you can come back and do this again later.</p>
-  <noscript>This page needs JavaScript to find your saved progress — as does the game itself.</noscript>
+  <noscript>This page needs JavaScript to find your saved progress: as does the game itself.</noscript>
 </main>
 <!-- Absolute, not relative: this same file is also published as 404.html, so
      it answers deep bookmarks like /pokemon-roulette/settings/ where a

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -18,7 +18,7 @@ cd "$(dirname "$0")/.."
 : "${CLOUDFLARE_ACCOUNT_ID:?set CLOUDFLARE_ACCOUNT_ID (Cloudflare dashboard -> Workers & Pages -> Account ID)}"
 
 if [[ -n $(git status --porcelain) ]]; then
-  echo "warning: working tree is dirty — deploying files that are not committed" >&2
+  echo "warning: working tree is dirty: deploying files that are not committed" >&2
 fi
 
 COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)

--- a/scripts/deploy-handoff.sh
+++ b/scripts/deploy-handoff.sh
@@ -28,7 +28,7 @@ node_modules/.bin/esbuild src/app/migration/handoff-page.ts \
 # The page is inert without its script: it would tell a player their progress
 # is being checked, forever, and offer them a link that carries nothing.
 grep -q 'migrate=' handoff/handoff.js || {
-  echo "error: the bundled script does not build a migrate link — refusing to publish." >&2
+  echo "error: the bundled script does not build a migrate link: refusing to publish." >&2
   exit 1
 }
 


### PR DESCRIPTION
The earlier sweep covered `src/`, `CLAUDE.md` and `README.md`. These four sit at the repository root and were skipped:

- `handoff/index.html`
- `scripts/deploy-cloudflare.sh`
- `scripts/deploy-handoff.sh`
- `deploy/cloudflare-pages.md`

The first one matters: it is the page **every existing player will meet** when the domain moves, and its body text still read *"tied to this address — so it does not follow you automatically"*.

Found by reading the rendered page during the shim rehearsal, not by grepping. That is the only reason it was caught before the page became permanent on the old origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)