### PR TITLE
Remove the gh-pages deploy script before it can undo the cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,6 @@ npm run build                                    # production build -> dist/poke
 npm test                                         # Karma/Jasmine, watch mode
 npm test -- --watch=false --browsers=ChromeHeadless   # what CI runs
 npm test -- --include='**/wheel.component.spec.ts'    # single spec file
-npm run deploy                                   # gh-pages, base-href /pokemon-roulette/
 ./scripts/deploy-cloudflare.sh                   # Cloudflare Pages, base-href / (needs cloudflare.env)
 ```
 
@@ -77,8 +76,16 @@ setting:
 
 | Where | Build | Base href |
 |---|---|---|
-| `zeroxm.github.io/pokemon-roulette/` | `npm run deploy` → gh-pages | `/pokemon-roulette/` |
+| `zeroxm.github.io/pokemon-roulette/` | the old build, frozen; `scripts/deploy-handoff.sh` replaces it at cutover | `/pokemon-roulette/` |
 | `pokemon-roulette.zeroxm.com.br` | `scripts/deploy-cloudflare.sh` → Cloudflare Pages | `/` |
+
+**There is deliberately no `npm run deploy`.** It published the game to
+gh-pages, and after the cutover that is the one command that would silently
+destroy the handoff page, taking with it every un-migrated player's only route
+to their collection. The script and its `angular.json` target were removed
+rather than documented, because a documented hazard is still one keystroke
+away. `scripts/deploy-handoff.sh` is the only thing that writes to gh-pages
+now, and it refuses to run without `--yes-replace-the-live-game`.
 
 **Do not "clean up" the gh-pages build.** It is still serving every current player, and it stays
 until UAT passes and the migration shim replaces it: see the release order in

--- a/angular.json
+++ b/angular.json
@@ -97,9 +97,6 @@
             ],
             "scripts": []
           }
-        },
-        "deploy": {
-          "builder": "angular-cli-ghpages:deploy"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "start": "ng serve --host 0.0.0.0 --port 4200",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
-    "deploy": "ng deploy --base-href=/pokemon-roulette/"
+    "test": "ng test"
   },
   "private": true,
   "dependencies": {

--- a/scripts/deploy-handoff.sh
+++ b/scripts/deploy-handoff.sh
@@ -47,6 +47,9 @@ fi
 cp handoff/index.html handoff/404.html
 
 echo "==> publishing handoff/ to gh-pages"
-npx --yes angular-cli-ghpages --dir=handoff --no-silent
+# The locally pinned copy, not `npx --yes`: this is the one command whose
+# failure mode is "every existing player loses the route to their collection",
+# so it should not depend on a fetch from the network at the moment it runs.
+npx angular-cli-ghpages --dir=handoff --no-silent
 
 echo "==> done. https://zeroxm.github.io/pokemon-roulette/"


### PR DESCRIPTION
`npm run deploy` published the game to gh-pages. **After the handoff page replaces it there, that same command silently puts the game back** and destroys the page, taking with it every un-migrated player's only route to their collection.

It is one line in `package.json` and the obvious thing to type.

So it's gone, along with its `angular.json` target, rather than documented. A documented hazard is still one keystroke away. `scripts/deploy-handoff.sh` is now the only thing that writes to gh-pages, and it already refuses to run without `--yes-replace-the-live-game`.

## One thing I kept

`angular-cli-ghpages` stays as a **pinned devDependency**, and `deploy-handoff.sh` now uses the local copy rather than `npx --yes`. That command's failure mode is losing every player's collection; it should not depend on a network fetch at the moment it runs.

537/537 tests, build unchanged at 1.57 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)