### PR TITLE
Point the README at the new address

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,12 +71,12 @@ Per-component CSS still has room: the largest, `mega-evolution-animation-modal.c
 
 ## Two deployments, on purpose
 
-The game is served from **both** URLs during the accounts rollout, and the two builds differ in one
-setting:
+The game is at `pokemon-roulette.zeroxm.com.br`. The old address still answers, with the handoff
+page rather than the game:
 
 | Where | Build | Base href |
 |---|---|---|
-| `zeroxm.github.io/pokemon-roulette/` | the old build, frozen; `scripts/deploy-handoff.sh` replaces it at cutover | `/pokemon-roulette/` |
+| `zeroxm.github.io/pokemon-roulette/` | the handoff page, published 2026-09-11 by `scripts/deploy-handoff.sh`. **Permanent**: players return after months, and it is their only route to a collection built before the move | `/pokemon-roulette/` |
 | `pokemon-roulette.zeroxm.com.br` | `scripts/deploy-cloudflare.sh` → Cloudflare Pages | `/` |
 
 **There is deliberately no `npm run deploy`.** It published the game to

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 A game involving Pokémon and Roulettes: a randomised run driven by spinning wheels. Pick a region,
 spin for what happens next, and try to reach the Champion with whatever the wheels give you.
 
-**Play it here: [zeroxm.github.io/pokemon-roulette](https://zeroxm.github.io/pokemon-roulette/)**
+**Play it here: [pokemon-roulette.zeroxm.com.br](https://pokemon-roulette.zeroxm.com.br/)**
+
+Moved from `zeroxm.github.io/pokemon-roulette/` on 2026-09-11. That address now
+serves a page that carries an existing player's Pokédex across, because
+`localStorage` belongs to an origin and does not follow a domain change on its
+own.
 
 Angular 22, standalone components, Bootstrap 5 + ng-bootstrap, `@ngx-translate` for six languages,
 deployed to GitHub Pages.


### PR DESCRIPTION
The README still linked to `zeroxm.github.io/pokemon-roulette/`, which now serves the handoff page. Anyone arriving from the repository would have met a "this has moved" notice and had no collection to carry across.

CLAUDE.md's deployment table described the handoff as something a future cutover *would* do. It happened, so the entry now records what actually matters about that page: **it is permanent**, because players return after months and it is their only route to a collection built before the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)